### PR TITLE
Support arbitrary `pub` commands

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -9,6 +9,16 @@
     triggers the default arguments.
 - Add `--use-get` optional flag for the `travis` command to use `pub get` 
   instead of `pub upgrade` in the generated script.
+- All `pub` commands are now available when running `mono_repo pub`.
+  - All arguments after `pub` are passed to it: try running `mono_repo help
+    pub` and `mono_repo pub help`.
+- Improved Flutter support:
+  - The `pub` command has `flutter` as an alias, so `mono_repo pub` is 
+    equivalent to `mono_repo flutter`.
+  - When using `mono_repo pub`, `flutter` will be used instead for any package 
+    with a dependency on the Flutter SDK.
+  - When using `mono_repo pub get` or `mono_repo pub upgrade`, the `packages`
+    argument needed by `flutter` is added automatically if `flutter` is used.
 
 ## 2.1.0
 

--- a/mono_repo/README.md
+++ b/mono_repo/README.md
@@ -35,7 +35,7 @@ Available commands:
   check       Check the state of the repository.
   help        Display help information for mono_repo.
   presubmit   Run the travis presubmits locally.
-  pub         Run `pub get` or `pub upgrade` against all packages.
+  pub         Run a `pub` command across all packages.
   travis      Configure Travis-CI for child packages.
 
 Run "mono_repo help <command>" for more information about a command.

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -251,7 +251,8 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
   final pkgDirs = rootConfig.map((pc) => pc.relativePath).toList();
 
   print(lightBlue.wrap(
-      'Running `pub ${args.join(' ')}` across ${pkgDirs.length} package(s).'));
+      'Running `${['pub', ...args].join(' ')}` across ${pkgDirs.length} package'
+      '${pkgDirs.length == 1 ? '' : 's'}.'));
 
   for (var config in rootConfig) {
     final dir = config.relativePath;
@@ -265,7 +266,7 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
 
     print('');
     print(wrapWith(
-        'Starting `$executable ${packageArgs.join(' ')}` in `$dir`...',
+        'Starting `${[executable, ...packageArgs].join(' ')}` in `$dir`...',
         [styleBold, lightBlue]));
     final workingDir = p.join(rootConfig.rootDirectory, dir);
 

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -275,10 +275,13 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
 
     Process proc;
     try {
-      proc = await Process.start(executable, packageArgs,
-          mode: ProcessStartMode.inheritStdio,
-          workingDirectory: workingDir,
-          runInShell: true);
+      proc = await Process.start(
+        executable,
+        packageArgs,
+        mode: ProcessStartMode.inheritStdio,
+        workingDirectory: workingDir,
+        runInShell: true,
+      );
     } on ProcessException {
       print(wrapWith(
           'ProcessException: `$executable` couldn\'t be started.'

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -276,7 +276,9 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
     Process proc;
     try {
       proc = await Process.start(executable, packageArgs,
-          mode: ProcessStartMode.inheritStdio, workingDirectory: workingDir);
+          mode: ProcessStartMode.inheritStdio,
+          workingDirectory: workingDir,
+          runInShell: true);
     } on ProcessException {
       print(wrapWith(
           'ProcessException: `$executable` couldn\'t be started.'

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -5,105 +5,260 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import '../root_config.dart';
 import 'mono_repo_command.dart';
 
-class PubCommand extends Command<void> {
-  PubCommand() {
-    addSubcommand(_PubSubCommand('get'));
-    addSubcommand(_PubSubCommand('upgrade'));
-  }
+class PubCommand extends MonoRepoCommand {
+  @override
+  ArgParser get argParser => _pubArgParser ??= _PubArgParser();
+  _PubArgParser _pubArgParser;
+
+  @override
+  String get description => 'Run a `pub` command across all packages';
 
   @override
   String get name => 'pub';
 
   @override
-  String get description =>
-      'Run `pub get` or `pub upgrade` against all packages.';
+  Future<void> run() => pub(rootConfig(), argResults.rest);
 }
 
-const _offline = 'offline';
-const _dryRun = 'dry-run';
-const _precompile = 'precompile';
+/// Implementation of [ArgParser] that delegates to an [allowAnything()] but
+/// allows compatibility with [Command] and [CommandRunner].
+///
+/// Specifically, the follow issues are addressed:
+/// - [Command]:
+///   - Attempts to [addFlag] a 'help' option, which isn't allowed by
+///   [allowAnything()] (ironically). We don't want that flag to be added
+///   anyway; we want `pub` or `flutter` to handle printing their own usage.
+///   [allowAnything()] throws an [UnsupportedError] so instead we just
+///   ignore the call and don't pass it on to the delegate.
+/// - [CommandRunner]:
+///   - Attempts to check the value of the 'help' option, which doesn't exist
+///   because we ignored [Command]'s adding it. This check isn't done via
+///   [_PubArgParser]'s own [ArgResults] from [parse], as this isn't ever the
+///   top-level [ArgParser]. Instead, as [CommandRunner] steps into the
+///   arguments for [PubCommand], it ends up being the [options] getter here
+///   which is checked for the 'help' option by an [ArgResults] created from
+///   the top-level (which is out of our control). To trick [CommandRunner],
+///   we return a [_PubOptions], itself a delegating class.
+class _PubArgParser implements ArgParser {
+  final ArgParser _delegate;
 
-class _PubSubCommand extends MonoRepoCommand {
+  _PubArgParser() : _delegate = ArgParser.allowAnything();
+
+  /// [_PubArgParser] can't have commands added to it, so we do nothing.
   @override
-  final String name;
+  ArgParser addCommand(String name, [ArgParser parser]) => parser;
 
-  _PubSubCommand(this.name) {
-    argParser
-      ..addFlag(_offline,
-          negatable: true,
-          defaultsTo: false,
-          help: 'Use cached packages instead of accessing the network.')
-      ..addFlag(_dryRun,
-          abbr: 'n',
-          defaultsTo: false,
-          negatable: false,
-          help: 'Precompile executables and transformed dependencies.')
-      ..addFlag(_precompile,
-          defaultsTo: true,
-          negatable: true,
-          help: "Report what dependencies would change but don't change any.");
-  }
+  /// [_PubArgParser] can't have flags added to it, so we do nothing.
+  @override
+  void addFlag(String name,
+      {String abbr,
+      String help,
+      bool defaultsTo = false,
+      bool negatable = true,
+      void Function(bool value) callback,
+      bool hide = false}) {}
+
+  /// [_PubArgParser] can't have options added to it, so we do nothing.
+  @override
+  void addMultiOption(String name,
+      {String abbr,
+      String help,
+      String valueHelp,
+      Iterable<String> allowed,
+      Map<String, String> allowedHelp,
+      Iterable<String> defaultsTo,
+      void Function(List<String> values) callback,
+      bool splitCommas = true,
+      bool hide = false}) {}
+
+  /// [_PubArgParser] can't have options added to it, so we do nothing.
+  @override
+  void addOption(String name,
+      {String abbr,
+      String help,
+      String valueHelp,
+      Iterable<String> allowed,
+      Map<String, String> allowedHelp,
+      String defaultsTo,
+      Function callback,
+      bool allowMultiple = false,
+      bool splitCommas,
+      bool hide = false}) {}
+
+  /// [_PubArgParser] can't have separators added to it, so we do nothing.
+  @override
+  void addSeparator(String text) {}
 
   @override
-  String get description => 'Run `pub $name` against all packages.';
+  bool get allowTrailingOptions => _delegate.allowTrailingOptions;
 
   @override
-  Future<void> run() => pub(
-        rootConfig(),
-        name,
-        offline: argResults[_offline] as bool,
-        dryRun: argResults[_dryRun] as bool,
-        preCompile: argResults[_precompile] as bool,
-      );
+  bool get allowsAnything => _delegate.allowsAnything;
+
+  @override
+  Map<String, ArgParser> get commands => _delegate.commands;
+
+  @override
+  Option findByAbbreviation(String abbr) => _delegate.findByAbbreviation(abbr);
+
+  /// [_PubArgParser] can't have options, so if asked about a default we return
+  /// null.
+  @override
+  dynamic getDefault(String option) => null;
+
+  @override
+  String getUsage() => _delegate.usage;
+
+  /// Return the options as a [_PubOptions] to trick [CommandRunner].
+  @override
+  Map<String, Option> get options => _PubOptions(_delegate.options);
+
+  /// Wrap the normal output with a `PubArgResults` to fail quieter than normal.
+  @override
+  ArgResults parse(Iterable<String> args) => _delegate.parse(args);
+
+  @override
+  String get usage => '''Any arguments given are passed verbatim to `pub`\n
+If a particular package uses Flutter, `flutter` is used rather than `pub`:
+- If the arguments begin with `get` or `upgrade`, `flutter packages` is used
+- Otherwise, `flutter` is used''';
+
+  @override
+  int get usageLineLength => _delegate.usageLineLength;
 }
 
-Future<void> pub(
-  RootConfig rootConfig,
-  String pubCommand, {
-  @required bool offline,
-  @required bool dryRun,
-  @required bool preCompile,
-}) async {
+/// Implementation of [Map] designed to trick [CommandRunner] into believing
+/// that any options it asks for did exist but were false.
+///
+/// This means that when [CommandRunner] checks the 'help' flag it assumes
+/// was added, it is told that the option had the value of false. This is in
+/// spite of the fact that an [allowAnything()] [ArgParser] can't have flags
+/// added and we ignored the addition of 'help' earlier in [_PubArgParser].
+/// [allowAnthing()] sets the options to be constantly empty, and for clarity
+/// we delegate to that value here, given in the constructor.
+///
+/// Conceptually, this class is a map that behaves as though it has no
+/// elements unless a specific one is requested: [containsKey] is always
+/// true, and the `[]` operator always returns a stub [_FalseOption].
+class _PubOptions implements Map<String, Option> {
+  final Map<String, Option> _delegate;
+
+  _PubOptions(Map<String, Option> delegate) : _delegate = delegate;
+
+  /// Return a [_FalseOption], in-line with the class documentation.
+  @override
+  Option operator [](Object key) => _FalseOption();
+
+  @override
+  void operator []=(String key, Option value) => false;
+
+  @override
+  void addAll(Map<String, Option> other) => _delegate.addAll(other);
+
+  @override
+  void addEntries(Iterable<MapEntry<String, Option>> newEntries) =>
+      _delegate.addEntries(newEntries);
+
+  @override
+  Map<RK, RV> cast<RK, RV>() => _delegate.cast();
+
+  @override
+  void clear() => _delegate.clear();
+
+  /// Return `true`, in-line with the class documentation.
+  @override
+  bool containsKey(Object key) => true;
+
+  @override
+  bool containsValue(Object value) => _delegate.containsValue(value);
+
+  @override
+  Iterable<MapEntry<String, Option>> get entries => _delegate.entries;
+
+  @override
+  void forEach(void Function(String key, Option value) f) =>
+      _delegate.forEach(f);
+
+  @override
+  bool get isEmpty => _delegate.isEmpty;
+
+  @override
+  bool get isNotEmpty => _delegate.isNotEmpty;
+
+  @override
+  Iterable<String> get keys => _delegate.keys;
+
+  @override
+  int get length => _delegate.length;
+
+  @override
+  Map<K2, V2> map<K2, V2>(
+          MapEntry<K2, V2> Function(String key, Option value) f) =>
+      _delegate.map(f);
+
+  @override
+  Option putIfAbsent(String key, Option Function() ifAbsent) =>
+      _delegate.putIfAbsent(key, ifAbsent);
+
+  @override
+  Option remove(Object key) => _delegate.remove(key);
+
+  @override
+  void removeWhere(bool Function(String key, Option value) predicate) =>
+      _delegate.removeWhere(predicate);
+
+  @override
+  Option update(String key, Option Function(Option value) update,
+          {Option Function() ifAbsent}) =>
+      _delegate.update(key, update);
+
+  @override
+  void updateAll(Option Function(String key, Option value) update) =>
+      _delegate.updateAll(update);
+
+  @override
+  Iterable<Option> get values => _delegate.values;
+}
+
+/// A stub [Option] that only exists to have a [getOrDefault] method that
+/// returns false.
+///
+/// Since [CommandRunner] only accesses the 'help' option by transitively
+/// checking that the key exists (handled by [_PubOptions] and by calling
+/// [getOrDefault] on the value, we can just implement that method and throw
+/// a [UnsupportedError] if anything else is called.
+class _FalseOption implements Option {
+  @override
+  dynamic getOrDefault(value) => false;
+
+  @override
+  void noSuchMethod(Invocation invocation) =>
+      UnsupportedError('Unimplemented method was called on FalseOption');
+}
+
+Future<void> pub(RootConfig rootConfig, List<String> args) async {
   final pkgDirs = rootConfig.map((pc) => pc.relativePath).toList();
-
-  // TODO(kevmoo): use UI-as-code features when min SDK is >= 2.3.0
-  final args = [pubCommand];
-  if (offline) {
-    args.add('--$_offline');
-  }
-
-  if (dryRun) {
-    args.add('--$_dryRun');
-  }
-
-  // Note: the default is `true`
-  if (!preCompile) {
-    args.add('--no-$_precompile');
-  }
 
   print(lightBlue.wrap(
       'Running `pub ${args.join(' ')}` across ${pkgDirs.length} package(s).'));
 
   for (var config in rootConfig) {
     final dir = config.relativePath;
-    List<String> packageArgs;
-    String executable;
-
-    if (config.hasFlutterDependency) {
-      executable = 'flutter';
-      packageArgs = ['packages']..addAll(args);
-    } else {
-      executable = pubPath;
-      packageArgs = args;
-    }
+    final packageArgs = [
+      if (config.hasFlutterDependency &&
+          (args.first == 'get' || args.first == 'upgrade'))
+        'packages',
+      ...args
+    ];
+    final executable = config.hasFlutterDependency ? 'flutter' : pubPath;
 
     print('');
     print(wrapWith(

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -266,7 +266,10 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
 
     print('');
     print(wrapWith(
-        'Starting `${[executable, ...packageArgs].join(' ')}` in `$dir`...',
+        'Starting `${[
+          config.hasFlutterDependency ? 'flutter' : 'pub',
+          ...packageArgs
+        ].join(' ')}` in `$dir`...',
         [styleBold, lightBlue]));
     final workingDir = p.join(rootConfig.rootDirectory, dir);
 

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -19,7 +19,7 @@ class PubCommand extends MonoRepoCommand {
   _PubArgParser _pubArgParser;
 
   @override
-  String get description => 'Run a `pub` command across all packages';
+  String get description => 'Run a `pub` command across all packages.';
 
   @override
   String get name => 'pub';

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -129,10 +129,10 @@ class _PubArgParser implements ArgParser {
   ArgResults parse(Iterable<String> args) => _delegate.parse(args);
 
   @override
-  String get usage => '''Any arguments given are passed verbatim to `pub`\n
+  String get usage => '''Any arguments given are passed verbatim to `pub`.\n
 If a particular package uses Flutter, `flutter` is used rather than `pub`:
-- If the arguments begin with `get` or `upgrade`, `flutter packages` is used
-- Otherwise, `flutter` is used''';
+- If the arguments begin with `get` or `upgrade`, `flutter packages` is used.
+- Otherwise, `flutter` is used.''';
 
   @override
   int get usageLineLength => _delegate.usageLineLength;

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -270,10 +270,18 @@ Future<void> pub(RootConfig rootConfig, List<String> args) async {
         [styleBold, lightBlue]));
     final workingDir = p.join(rootConfig.rootDirectory, dir);
 
-    final proc = await Process.start(executable, packageArgs,
-        mode: ProcessStartMode.inheritStdio, workingDirectory: workingDir);
+    Process proc;
+    try {
+      proc = await Process.start(executable, packageArgs,
+          mode: ProcessStartMode.inheritStdio, workingDirectory: workingDir);
+    } on ProcessException {
+      print(wrapWith(
+          'ProcessException: `$executable` couldn\'t be started.'
+          '  Are you sure it is installed?',
+          [styleBold, red]));
+    }
 
-    final exit = await proc.exitCode;
+    final exit = await proc?.exitCode ?? 1;
 
     if (exit == 0) {
       print(wrapWith('`$dir`: success!', [styleBold, green]));

--- a/mono_repo/lib/src/commands/pub.dart
+++ b/mono_repo/lib/src/commands/pub.dart
@@ -25,6 +25,9 @@ class PubCommand extends MonoRepoCommand {
   String get name => 'pub';
 
   @override
+  List<String> get aliases => ['flutter'];
+
+  @override
   Future<void> run() => pub(rootConfig(), argResults.rest);
 }
 

--- a/mono_repo/test/mono_repo_test.dart
+++ b/mono_repo/test/mono_repo_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
 void main() {
-  test('pub get gets dependencies', () async {
+  test('running without arguments produces expected help output', () async {
     var process = await TestProcess.start('pub', ['run', 'mono_repo']);
 
     var output = await process.stdoutStream().join('\n');
@@ -38,7 +38,7 @@ Available commands:
   check       Check the state of the repository.
   help        Display help information for mono_repo.
   presubmit   Run the travis presubmits locally.
-  pub         Run a `pub` command across all packages
+  pub         Run a `pub` command across all packages.
   travis      Configure Travis-CI for child packages.
 
 Run "mono_repo help <command>" for more information about a command.''';

--- a/mono_repo/test/mono_repo_test.dart
+++ b/mono_repo/test/mono_repo_test.dart
@@ -38,7 +38,7 @@ Available commands:
   check       Check the state of the repository.
   help        Display help information for mono_repo.
   presubmit   Run the travis presubmits locally.
-  pub         Run `pub get` or `pub upgrade` against all packages.
+  pub         Run a `pub` command across all packages
   travis      Configure Travis-CI for child packages.
 
 Run "mono_repo help <command>" for more information about a command.''';

--- a/mono_repo/test/pub_command_test.dart
+++ b/mono_repo/test/pub_command_test.dart
@@ -8,11 +8,14 @@ import 'package:test/test.dart';
 import 'package:mono_repo/src/package_config.dart';
 import 'package:test_process/test_process.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:path/path.dart' as p;
 
 void main() {
+  final monoRepoExecutable = p.join(p.current, 'bin', 'mono_repo.dart');
+
   test('help command pub output', () async {
     var process =
-        await TestProcess.start('pub', ['run', 'mono_repo', 'help', 'pub']);
+        await TestProcess.start('dart', [monoRepoExecutable, 'help', 'pub']);
 
     var output = await process.stdoutStream().join('\n');
     expect(output, _helpCommandPubOutput);
@@ -36,13 +39,12 @@ name: pkg_b
     ]).create();
 
     var process = await TestProcess.start(
-        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
 
-    var expected =
-        Process.runSync('pub', ['--help'], workingDirectory: d.sandbox).stdout;
+    var expected = Process.runSync('pub', ['--help']).stdout;
 
     expect(actualOutput, startsWith('Running `pub --help` across 2 packages.'));
     expect(actualOutput, contains(expected));
@@ -66,7 +68,7 @@ name: pkg_b
     ]).create();
 
     var process = await TestProcess.start(
-        'pub', ['run', 'mono_repo', 'pub', 'get', '--help'],
+        'dart', [monoRepoExecutable, 'pub', 'get', '--help'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
@@ -91,7 +93,7 @@ name: pkg_a
     ]).create();
 
     var process = await TestProcess.start(
-        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
@@ -109,7 +111,7 @@ name: pkg_a
       ''')
     ]).create();
 
-    var process = await TestProcess.start('pub', ['run', 'mono_repo', 'pub'],
+    var process = await TestProcess.start('dart', [monoRepoExecutable, 'pub'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
@@ -138,7 +140,7 @@ name: pkg_b
     ]).create();
 
     var process = await TestProcess.start(
-        'pub', ['run', 'mono_repo', 'pub', 'get'],
+        'dart', [monoRepoExecutable, 'pub', 'get'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
@@ -169,7 +171,7 @@ name: pkg_b
     ]).create();
 
     var process = await TestProcess.start(
-        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
     var actualOutput = await process.stderrStream().join('\n');
@@ -183,10 +185,10 @@ name: pkg_b
 final _helpCommandPubOutput = '''Run a `pub` command across all packages.
 
 Usage: mono_repo pub [arguments]
-Any arguments given are passed verbatim to `pub`
+Any arguments given are passed verbatim to `pub`.
 
 If a particular package uses Flutter, `flutter` is used rather than `pub`:
-- If the arguments begin with `get` or `upgrade`, `flutter packages` is used
-- Otherwise, `flutter` is used
+- If the arguments begin with `get` or `upgrade`, `flutter packages` is used.
+- Otherwise, `flutter` is used.
 
 Run "mono_repo help" to see global options.''';

--- a/mono_repo/test/pub_command_test.dart
+++ b/mono_repo/test/pub_command_test.dart
@@ -1,0 +1,192 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:mono_repo/src/package_config.dart';
+import 'package:test_process/test_process.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  test('help command pub output', () async {
+    var process =
+        await TestProcess.start('pub', ['run', 'mono_repo', 'help', 'pub']);
+
+    var output = await process.stdoutStream().join('\n');
+    expect(output, _helpCommandPubOutput);
+
+    await process.shouldExit(0);
+  });
+
+  test('--help is passed to pub', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+      ''')
+    ]).create();
+
+    await d.dir('pkg_b', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_b
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start(
+        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    var expected =
+        Process.runSync('pub', ['--help'], workingDirectory: d.sandbox).stdout;
+
+    expect(actualOutput, startsWith('Running `pub --help` across 2 packages.'));
+    expect(actualOutput, contains(expected));
+
+    await process.shouldExit(0);
+  });
+
+  test('pub subcommands support their normal arguments', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+      ''')
+    ]).create();
+
+    await d.dir('pkg_b', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_b
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start(
+        'pub', ['run', 'mono_repo', 'pub', 'get', '--help'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    var expected =
+        Process.runSync('pub', ['get', '--help'], workingDirectory: d.sandbox)
+            .stdout;
+
+    expect(actualOutput,
+        startsWith('Running `pub get --help` across 2 packages.'));
+    expect(actualOutput, contains(expected));
+
+    await process.shouldExit(0);
+  });
+
+  test('a single package is referenced if there is only one', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start(
+        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    expect(actualOutput, startsWith('Running `pub --help` across 1 package.'));
+  });
+
+  test(
+      'if there are no arguments, the `pub` command is still printed '
+      'correctly', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start('pub', ['run', 'mono_repo', 'pub'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    expect(actualOutput, startsWith('Running `pub` across 1 package.'));
+    expect(actualOutput, contains('Starting `pub` in `'));
+  });
+
+  // flutter doesn't need to be installed, it is okay if finding it fails
+  test('a flutter dependency is handled correctly for get', () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+dependencies:
+  flutter:
+    sdk: flutter
+      ''')
+    ]).create();
+
+    await d.dir('pkg_b', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_b
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start(
+        'pub', ['run', 'mono_repo', 'pub', 'get'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    expect(actualOutput, startsWith('Running `pub get` across 2 packages.'));
+    expect(actualOutput, contains('Starting `pub get` in `'));
+    expect(actualOutput, contains('Starting `flutter packages get` in `'));
+  });
+
+  // flutter doesn't need to be installed, it is okay if finding it fails
+  test('a flutter dependency is handled correctly for other commands',
+      () async {
+    await d.dir('pkg_a', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_a
+dependencies:
+  flutter:
+    sdk: flutter
+      ''')
+    ]).create();
+
+    await d.dir('pkg_b', [
+      d.file(monoPkgFileName),
+      d.file('pubspec.yaml', '''
+name: pkg_b
+      ''')
+    ]).create();
+
+    var process = await TestProcess.start(
+        'pub', ['run', 'mono_repo', 'pub', '--help'],
+        workingDirectory: d.sandbox);
+
+    var actualOutput = await process.stderrStream().join('\n');
+
+    expect(actualOutput, startsWith('Running `pub --help` across 2 packages.'));
+    expect(actualOutput, contains('Starting `pub --help` in `'));
+    expect(actualOutput, contains('Starting `flutter --help` in `'));
+  });
+}
+
+final _helpCommandPubOutput = '''Run a `pub` command across all packages.
+
+Usage: mono_repo pub [arguments]
+Any arguments given are passed verbatim to `pub`
+
+If a particular package uses Flutter, `flutter` is used rather than `pub`:
+- If the arguments begin with `get` or `upgrade`, `flutter packages` is used
+- Otherwise, `flutter` is used
+
+Run "mono_repo help" to see global options.''';

--- a/mono_repo/test/pub_command_test.dart
+++ b/mono_repo/test/pub_command_test.dart
@@ -42,7 +42,7 @@ name: pkg_b
         'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     var expected = Process.runSync('pub', ['--help']).stdout;
 
@@ -71,7 +71,7 @@ name: pkg_b
         'dart', [monoRepoExecutable, 'pub', 'get', '--help'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     var expected =
         Process.runSync('pub', ['get', '--help'], workingDirectory: d.sandbox)
@@ -96,7 +96,7 @@ name: pkg_a
         'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     expect(actualOutput, startsWith('Running `pub --help` across 1 package.'));
   });
@@ -114,7 +114,7 @@ name: pkg_a
     var process = await TestProcess.start('dart', [monoRepoExecutable, 'pub'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     expect(actualOutput, startsWith('Running `pub` across 1 package.'));
     expect(actualOutput, contains('Starting `pub` in `'));
@@ -143,7 +143,7 @@ name: pkg_b
         'dart', [monoRepoExecutable, 'pub', 'get'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     expect(actualOutput, startsWith('Running `pub get` across 2 packages.'));
     expect(actualOutput, contains('Starting `pub get` in `'));
@@ -174,7 +174,7 @@ name: pkg_b
         'dart', [monoRepoExecutable, 'pub', '--help'],
         workingDirectory: d.sandbox);
 
-    var actualOutput = await process.stderrStream().join('\n');
+    var actualOutput = await process.stdoutStream().join('\n');
 
     expect(actualOutput, startsWith('Running `pub --help` across 2 packages.'));
     expect(actualOutput, contains('Starting `pub --help` in `'));


### PR DESCRIPTION
Fixes #120 and #45. 

Ironically enough, [`ArgParser.allowAnything()`](https://pub.dev/documentation/args/latest/args/ArgParser/ArgParser.allowAnything.html) actually has a number of significant restrictions that make it incompatible with [`Command`](https://pub.dev/documentation/args/latest/command_runner/Command-class.html) and [`CommandRunner`](https://pub.dev/documentation/args/latest/command_runner/CommandRunner-class.html). The `pub` command now uses a custom ArgParser that wraps `allowAnything()` to maintain compatibility. TL;DR: rather than hardcoding `pub`'s options, we now just pass all text to the `pub` executable. All of the old functionality is retained and we get the rest of `pub` for free.

I added in some usability fixes for Flutter too, I was able to `mono_repo pub get` on a Flutter package without crashing like #45 suggested would happen. 

The changes are all backwards compatible; nothing should be breaking. Changelog entries:
> - All `pub` commands are now available when running `mono_repo pub`.
>   - All arguments after `pub` are passed to it: try running `mono_repo help
>     pub` and `mono_repo pub help`.
> - Improved Flutter support:
>   - The `pub` command has `flutter` as an alias, so `mono_repo pub` is 
>     equivalent to `mono_repo flutter`.
>   - When using `mono_repo pub`, `flutter` will be used instead for any package 
>     with a dependency on the Flutter SDK.
>   - When using `mono_repo pub get` or `mono_repo pub upgrade`, the `packages`
>     argument needed by `flutter` is added automatically if `flutter` is used.

Some of those entries aren't entirely new, just rewritten, but they weren't elsewhere in the changelog so I figured I'd include them. 

Updated tests to cover all of this; on the new test file I added the Dart author copyright header from [here](https://github.com/dart-lang/sdk/blob/master/CONTRIBUTING.md#coding-style), wasn't sure what year to put so I used 2019.