### PR TITLE
Bump min Dart SDK to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: dart
 jobs:
   include:
     - stage: smoke_test
-      name: "SDK: 2.6.0; PKGS: mono_repo, test_pkg; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKGS: mono_repo, test_pkg; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo test_pkg"
       script: ./tool/travis.sh dartanalyzer_1
@@ -16,14 +16,14 @@ jobs:
       env: PKGS="mono_repo test_pkg"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: build
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
+      dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: build
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
+      dart: "2.7.0"
       os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
@@ -40,14 +40,14 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_0
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
+      dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
+      dart: "2.7.0"
       os: windows
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1
@@ -64,14 +64,14 @@ jobs:
       env: PKGS="mono_repo"
       script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: test_pkg; TASKS: `pub run test`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: test_pkg; TASKS: `pub run test`"
+      dart: "2.7.0"
       os: linux
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test
     - stage: unit_test
-      name: "SDK: 2.6.0; PKG: test_pkg; TASKS: `pub run test`"
-      dart: "2.6.0"
+      name: "SDK: 2.7.0; PKG: test_pkg; TASKS: `pub run test`"
+      dart: "2.7.0"
       os: windows
       env: PKGS="test_pkg"
       script: ./tool/travis.sh test

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.1
 
-- Require Dart SDK `>=2.6.0 <3.0.0`.
+- Require Dart SDK `>=2.7.0 <3.0.0`.
 
 ## 2.3.0
 

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/google/mono_repo.dart for details
 dart:
-- 2.6.0
+- 2.7.0
 - dev
 
 stages:
@@ -11,7 +11,7 @@ stages:
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .
-    dart: [2.6.0]
+    dart: [2.7.0]
 - build:
   - command: pub run build_runner build test --delete-conflicting-outputs
     os:

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.3.1-dev
 homepage: https://github.com/google/mono_repo.dart
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   args: ^1.4.0

--- a/test_pkg/mono_pkg.yaml
+++ b/test_pkg/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/google/mono_repo.dart for details
 dart:
-- 2.6.0
+- 2.7.0
 - dev
 
 stages:
@@ -11,7 +11,7 @@ stages:
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .
-    dart: [2.6.0]
+    dart: [2.7.0]
 - unit_test:
   - test:
     os:

--- a/test_pkg/pubspec.yaml
+++ b/test_pkg/pubspec.yaml
@@ -2,7 +2,7 @@ name: test_pkg
 publish_to: none
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
Works-around issue with testing Dart 2.6 in CI and changes to pkg:analyzer