### PR TITLE
Add a --validate flag to the travis command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.3.1-dev
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,59 +10,65 @@ jobs:
       env: PKGS="mono_repo test_pkg"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: smoke_test
-      name: "SDK: dev; PKGS: mono_repo, test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKG: mono_repo; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`, `cd ../ && dart mono_repo/bin/mono_repo.dart travis --validate`]"
       dart: dev
       os: linux
-      env: PKGS="mono_repo test_pkg"
+      env: PKGS="mono_repo"
+      script: ./tool/travis.sh dartfmt dartanalyzer_0 command_0
+    - stage: smoke_test
+      name: "SDK: dev; PKG: test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: dev
+      os: linux
+      env: PKGS="test_pkg"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: build
       name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
+      script: ./tool/travis.sh command_1
     - stage: build
       name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: "2.7.0"
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
+      script: ./tool/travis.sh command_1
     - stage: build
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
+      script: ./tool/travis.sh command_1
     - stage: build
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner build test --delete-conflicting-outputs`"
       dart: dev
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_0
+      script: ./tool/travis.sh command_1
     - stage: unit_test
       name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
       dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
+      script: ./tool/travis.sh command_2
     - stage: unit_test
       name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
       dart: "2.7.0"
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
+      script: ./tool/travis.sh command_2
     - stage: unit_test
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
+      script: ./tool/travis.sh command_2
     - stage: unit_test
       name: "SDK: dev; PKG: mono_repo; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
       os: windows
       env: PKGS="mono_repo"
-      script: ./tool/travis.sh command_1
+      script: ./tool/travis.sh command_2
     - stage: unit_test
       name: "SDK: 2.7.0; PKG: test_pkg; TASKS: `pub run test`"
       dart: "2.7.0"

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,5 +1,11 @@
-## 2.3.1
+## 2.4.0
 
+- Adds a `--validate` option to the `travis` command.
+  - You can configure this to run from any of your `mono_pkg.yaml` files using
+    a command job like this:
+    
+    `command: "cd ../ && pub global run mono_repo travis --validate"`.
+  - We may make this easier to configure in the future.
 - Require Dart SDK `>=2.7.0 <3.0.0`.
 
 ## 2.3.0

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -45,51 +45,110 @@ class TravisCommand extends MonoRepoCommand {
           negatable: false,
           help:
               'If the generated `$travisShPath` file should use `pub get` for '
-              'dependencies instead of `pub upgrade`.');
+              'dependencies instead of `pub upgrade`.')
+      ..addFlag('validate',
+          negatable: false,
+          help: 'Validates that the existing travis config is up to date with '
+              'the current configuration. Does not write any files.');
   }
 
   @override
   void run() => generateTravisConfig(rootConfig(),
       prettyAnsi: argResults['pretty-ansi'] as bool,
-      useGet: argResults['use-get'] as bool);
+      useGet: argResults['use-get'] as bool,
+      validateOnly: argResults['validate'] as bool);
 }
 
 void generateTravisConfig(
   RootConfig configs, {
   bool prettyAnsi = true,
   bool useGet = false,
+  bool validateOnly = false,
   String pkgVersion,
 }) {
   prettyAnsi ??= true;
   useGet ??= false;
   pkgVersion ??= packageVersion;
+  validateOnly ??= false;
+  final travisConfig = GeneratedTravisConfig.generate(configs,
+      prettyAnsi: prettyAnsi, useGet: useGet);
+  if (validateOnly) {
+    _checkTravisYml(configs.rootDirectory, travisConfig);
+    _checkTravisScript(configs.rootDirectory, travisConfig);
+  } else {
+    _writeTravisYml(configs.rootDirectory, travisConfig);
+    _writeTravisScript(configs.rootDirectory, travisConfig);
+  }
+}
 
-  _logPkgs(configs);
+/// Container class for the generated yaml and shell scripts for travis.
+class GeneratedTravisConfig {
+  final String travisYml;
+  final String travisSh;
 
-  final commandsToKeys = extractCommands(configs);
+  GeneratedTravisConfig._(this.travisYml, this.travisSh);
 
-  _writeTravisYml(configs.rootDirectory, configs, commandsToKeys, pkgVersion);
+  factory GeneratedTravisConfig.generate(
+    RootConfig configs, {
+    bool prettyAnsi = true,
+    bool useGet = false,
+    String pkgVersion,
+  }) {
+    prettyAnsi ??= true;
+    useGet ??= false;
+    pkgVersion ??= packageVersion;
 
-  _writeTravisScript(
-      configs.rootDirectory,
-      _calculateTaskEntries(commandsToKeys, prettyAnsi),
-      prettyAnsi,
-      useGet ? 'get' : 'upgrade',
-      pkgVersion);
+    _logPkgs(configs);
+
+    final commandsToKeys = extractCommands(configs);
+
+    final yml = _travisYml(configs, commandsToKeys, pkgVersion);
+
+    final sh = _travisSh(_calculateTaskEntries(commandsToKeys, prettyAnsi),
+        prettyAnsi, useGet ? 'get' : 'upgrade', pkgVersion);
+
+    return GeneratedTravisConfig._(yml, sh);
+  }
+}
+
+/// Thrown if generated config does not match existing config when running with
+/// the `--validate` option.
+class TravisConfigOutOfDateException extends UserException {
+  TravisConfigOutOfDateException()
+      : super('Generated travis config is out of date',
+            details: 'Rerun `mono_repo travis` to update generated config');
+}
+
+/// Check existing `.travis.yml` versus the content in [config].
+///
+/// Throws a [TravisConfigOutOfDateException] if they do not match.
+void _checkTravisYml(String rootDirectory, GeneratedTravisConfig config) {
+  final yamlFile = File(p.join(rootDirectory, travisFileName));
+  if (!yamlFile.existsSync() ||
+      yamlFile.readAsStringSync() != config.travisYml) {
+    throw TravisConfigOutOfDateException();
+  }
 }
 
 /// Write `.travis.yml`
-void _writeTravisYml(String rootDirectory, RootConfig configs,
-    Map<String, String> commandsToKeys, String pkgVersion) {
+void _writeTravisYml(String rootDirectory, GeneratedTravisConfig config) {
   final travisPath = p.join(rootDirectory, travisFileName);
-  File(travisPath)
-      .writeAsStringSync(_travisYml(configs, commandsToKeys, pkgVersion));
+  File(travisPath).writeAsStringSync(config.travisYml);
   print(styleDim.wrap('Wrote `$travisPath`.'));
 }
 
+/// Checks the existing `tool/travis.sh` versus the content in [config].
+///
+/// Throws a [TravisConfigOutOfDateException] if they do not match.
+void _checkTravisScript(String rootDirectory, GeneratedTravisConfig config) {
+  final shFile = File(p.join(rootDirectory, travisShPath));
+  if (!shFile.existsSync() || shFile.readAsStringSync() != config.travisSh) {
+    throw TravisConfigOutOfDateException();
+  }
+}
+
 /// Write `tool/travis.sh`
-void _writeTravisScript(String rootDirectory, List<String> taskEntries,
-    bool prettyAnsi, String pubDependencyCommand, String pkgVersion) {
+void _writeTravisScript(String rootDirectory, GeneratedTravisConfig config) {
   final travisFilePath = p.join(rootDirectory, travisShPath);
   final travisScript = File(travisFilePath);
 
@@ -106,8 +165,7 @@ void _writeTravisScript(String rootDirectory, List<String> taskEntries,
     }
   }
 
-  travisScript.writeAsStringSync(
-      _travisSh(taskEntries, prettyAnsi, pubDependencyCommand, pkgVersion));
+  travisScript.writeAsStringSync(config.travisSh);
   // TODO: be clever w/ `travisScript.statSync().mode` to see if it's executable
   print(styleDim.wrap('Wrote `$travisFilePath`.'));
 }

--- a/mono_repo/lib/src/commands/travis.dart
+++ b/mono_repo/lib/src/commands/travis.dart
@@ -81,7 +81,7 @@ void generateTravisConfig(
   }
 }
 
-/// Container class for the generated yaml and shell scripts for travis.
+/// The generated yaml and shell script content for travis.
 class GeneratedTravisConfig {
   final String travisYml;
   final String travisSh;

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.3.1-dev';
+const packageVersion = '2.4.0';

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -8,6 +8,8 @@ stages:
   - group:
     - dartfmt
     - dartanalyzer: --fatal-infos --fatal-warnings .
+    # A bit weird, this should really be a global task but we don't have those.
+    - command: cd ../ && dart mono_repo/bin/mono_repo.dart travis --validate
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 2.3.1-dev
+version: 2.4.0
 homepage: https://github.com/google/mono_repo.dart
 
 environment:

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -54,7 +54,7 @@ stages:
 ''';
 
 const _travisYml = r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:
@@ -94,7 +94,7 @@ cache:
 
 final _travisSh = '''
 #!/bin/bash
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 
 $windowsBoilerplate
 '''

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -10,10 +10,10 @@ import 'package:mono_repo/src/user_exception.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
-Future<void> testGenerateTravisConfig() async {
+Future<void> testGenerateTravisConfig({bool validateOnly = false}) async {
   overrideAnsiOutput(false, () {
     generateTravisConfig(RootConfig(rootDirectory: d.sandbox),
-        pkgVersion: '1.2.3');
+        pkgVersion: '1.2.3', validateOnly: validateOnly);
   });
 }
 

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -167,15 +167,6 @@ name: pkg_name
           throwsA(isA<UserException>()));
     });
 
-    test('throws if the previous config doesn\'t match', () async {
-      await d.file(travisFileName, '').create();
-      await d.dir('tool', [
-        d.file('travis.sh', ''),
-      ]).create();
-      await expectLater(testGenerateTravisConfig(validateOnly: true),
-          throwsA(isA<UserException>()));
-    });
-
     test('doesn\'t throw if the previous config is up to date', () async {
       await expectLater(
           testGenerateTravisConfig,

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -291,7 +291,7 @@ name: pkg_b
         ])));
 
     await d.file(travisFileName, r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:
@@ -336,7 +336,7 @@ cache:
             travisShPath,
             '''
 #!/bin/bash
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 
 $windowsBoilerplate
 '''
@@ -439,7 +439,7 @@ name: pkg_b
         ])));
 
     await d.file(travisFileName, r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:
@@ -484,7 +484,7 @@ cache:
             travisShPath,
             '''
 #!/bin/bash
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 
 $windowsBoilerplate
 '''
@@ -597,7 +597,7 @@ name: pkg_a
         ])));
 
     await d.file(travisFileName, r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:
@@ -632,7 +632,7 @@ cache:
             travisShPath,
             '''
 #!/bin/bash
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 
 $windowsBoilerplate
 '''
@@ -739,7 +739,7 @@ travis:
   after_failure:
   - tool/report_failure.sh
 ''', contains(r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 # Custom configuration
@@ -977,7 +977,7 @@ jobs:
 
 const _config2Shell = '''
 #!/bin/bash
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 
 $windowsBoilerplate
 '''
@@ -1078,7 +1078,7 @@ exit ${EXIT_CODE}
 """;
 
 const _config2Yaml = r'''
-# Created with package:mono_repo v1.2.3
+# Created with package:mono_repo v2.4.0
 language: dart
 
 jobs:

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v2.3.1-dev
+# Created with package:mono_repo v2.4.0
 
 # Support built in commands on windows out of the box.
 function pub {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -55,10 +55,14 @@ for PKG in ${PKGS}; do
     echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
     case ${TASK} in
     command_0)
+      echo 'cd ../ && dart mono_repo/bin/mono_repo.dart travis --validate'
+      cd ../ && dart mono_repo/bin/mono_repo.dart travis --validate || EXIT_CODE=$?
+      ;;
+    command_1)
       echo 'pub run build_runner build test --delete-conflicting-outputs'
       pub run build_runner build test --delete-conflicting-outputs || EXIT_CODE=$?
       ;;
-    command_1)
+    command_2)
       echo 'pub run build_runner test --delete-conflicting-outputs -- -P presubmit'
       pub run build_runner test --delete-conflicting-outputs -- -P presubmit || EXIT_CODE=$?
       ;;


### PR DESCRIPTION
Validates that the current generated config is up to date, exits with a non-zero exit code if not and tells you to regenerate the config.

Also configure the check to be enabled for this repo.

**Note**: configuring this check is a bit awkward, see my mono_pkg.yaml config I added. We likely want to add the ability to add repo level jobs? But that is a separate task, this still has value on its own.  