### PR TITLE
mono_repo.yaml: added support for `self_validate` boolean value

### DIFF
--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## 2.5.0-dev
 
 * Provide a better error when parsing a poorly formatted Yaml file.
-* `mono_pkg.yaml`:
-  * Task `command` entry: correctly handle a `List` containing strings.
 * `mono_repo.yaml`:
+  * **NEW!** Added support for `self_validate` boolean value.
+    If `true`, creates a shell script and associated task to install the same
+    version of `mono_repo` during CI and run `mono_repo travis --validate` to
+    ensure all files are up-to-date.
   * Respect the ordering of `stages`, if configured.
   * Allow `stages` values to be just a string – allows defining an explicit
     ordering of stages. 
+* `mono_pkg.yaml`:
+  * Task `command` entry: correctly handle a `List` containing strings.
 
 ## 2.4.0
 

--- a/mono_repo/lib/src/commands/travis/travis_self_validate.dart
+++ b/mono_repo/lib/src/commands/travis/travis_self_validate.dart
@@ -1,0 +1,19 @@
+import '../../version.dart';
+
+String generateSelfValidate() => '''
+#!/bin/bash
+# Created with package:mono_repo v$packageVersion
+
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ \$TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "\$@"
+    else
+        command pub "\$@"
+    fi
+}
+
+set -v -e
+pub global activate mono_repo $packageVersion
+pub global run mono_repo travis --validate
+''';

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -14,6 +14,7 @@ part 'package_config.g.dart';
 const monoPkgFileName = 'mono_pkg.yaml';
 const travisFileName = '.travis.yml';
 const travisShPath = 'tool/travis.sh';
+const travisSelfValidateScriptPath = 'tool/mono_repo_self_validate.sh';
 
 class PackageConfig {
   final String relativePath;


### PR DESCRIPTION
If `true`, creates a shell script and associated task to install the same
version of `mono_repo` during CI and run `mono_repo travis --validate` to
ensure all files are up-to-date.