### PR TITLE
Remove --use-get flag on Travis command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.6.0-dev
+# Created with package:mono_repo v3.0.0-dev
 language: dart
 
 jobs:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 2.6.0-dev
+## 3.0.0-dev
 
 * `mono_repo.yaml`:
   * **NEW!** Added support for `pub_action` value.
     Can be one of `get` or `upgrade` (default) to change the package request
     behavior in each action.
-* **DEPRECATED** `--use-get` command-line flag. Use `pub_action` instead.
+* `travis` command:
+  * **BREAKING** Removed `--use-get` command-line flag. Use `pub_action`
+  setting in `mono_repo.yaml` instead.
 
 ## 2.5.0
 

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.6.0-dev';
+const packageVersion = '3.0.0-dev';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 2.6.0-dev
+version: 3.0.0-dev
 homepage: https://github.com/google/mono_repo.dart
 
 environment:

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -16,7 +16,6 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void testGenerateTravisConfig({
   bool validateOnly = false,
-  bool useGet,
   Object printMatcher,
 }) {
   printMatcher ??= isEmpty;
@@ -31,7 +30,6 @@ void testGenerateTravisConfig({
         false,
         () => generateTravisConfig(
           RootConfig(rootDirectory: d.sandbox),
-          useGet: useGet,
           validateOnly: validateOnly,
         ),
       ),

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -253,31 +253,6 @@ environment:
     await d.file(travisShPath, travisShellOutput).validate();
   });
 
-  test('using `get` in place of `upgrade`', () async {
-    await d.dir('sub_pkg', [
-      d.file(monoPkgFileName, testConfig2),
-      d.file('pubspec.yaml', '''
-name: pkg_name
-      ''')
-    ]).create();
-
-    testGenerateTravisConfig(
-      useGet: true,
-      printMatcher: stringContainsInOrder([
-        'The `--use-get` flag is deprecated. Use `pub_action: get` value in '
-            '`mono_repo.yaml` instead.',
-        'package:sub_pkg',
-        'Make sure to mark `tool/travis.sh` as executable.'
-      ]),
-    );
-
-    // replacement isn't actually how useGet works, but it is a concise test
-    await d
-        .file(travisShPath, travisShellOutput.replaceAll('upgrade', 'get'))
-        .validate();
-    await d.file(travisFileName, travisYamlOutput).validate();
-  });
-
   test('two flavors of dartfmt', () async {
     await d.dir('pkg_a', [
       d.file(monoPkgFileName, r'''

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v2.6.0-dev
+# Created with package:mono_repo v3.0.0-dev
 
 # Support built in commands on windows out of the box.
 function pub {


### PR DESCRIPTION
Follow-up to 13be1b0e0c805482b09364ca0641e6c1aea4f761 (#212) 
This is rarely used. It's much to keep all settings in the configuration