### PR TITLE
Use version of pkg:yaml that keeps Maps ordered

### DIFF
--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -100,13 +100,11 @@ class MonoConfig {
       }
     }
 
-    // Removing this at the last minute so any throw CheckedFromJsonException
-    // will have the right value
-    // ... but the code that writes the values won't write stages separately
-    travis.remove('stages');
-
     return MonoConfig._(
-      travis: travis.map((k, v) => MapEntry(k as String, v)),
+      // Removing 'stages' so any `throw CheckedFromJsonException` will have the
+      // right value, but the code that writes the values won't write stages
+      // separately
+      travis: travis.map((k, v) => MapEntry(k as String, v))..remove('stages'),
       conditionalStages: conditionalStages,
       mergeStages: mergeStages,
       selfValidateStage: selfValidateStage,

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -96,7 +96,7 @@ class PackageConfig {
               monoPkgYaml,
               'dart',
               'RawConfig',
-              '"dart" must be an array with at least one value.',
+              'The value for "dart" must be an array with at least one value.',
             );
           }
 
@@ -107,11 +107,9 @@ class PackageConfig {
             );
           }
 
-          throw CheckedFromJsonException(
-            monoPkgYaml,
-            'dart',
-            'RawConfig',
-            '"dart" is missing.',
+          throw ParsedYamlException(
+            'A "dart" key is required.',
+            job as YamlMap,
           );
         } else {
           sdkConfigUsed = true;

--- a/mono_repo/lib/src/root_config.dart
+++ b/mono_repo/lib/src/root_config.dart
@@ -53,9 +53,7 @@ PackageConfig _packageConfigFromDir(
     sourceUrl: pubspecFile.path,
   );
 
-  return createWithCheck(
-    () => PackageConfig.parse(pkgRelativePath, pubspec, pkgConfigYaml),
-  );
+  return PackageConfig.parse(pkgRelativePath, pubspec, pkgConfigYaml);
 }
 
 class RootConfig extends ListBase<PackageConfig> {

--- a/mono_repo/lib/src/yaml.dart
+++ b/mono_repo/lib/src/yaml.dart
@@ -58,7 +58,7 @@ Map yamlMapOrNull(String rootDir, String relativeFilePath) {
   final yamlFile = File(p.join(rootDir, relativeFilePath));
 
   if (yamlFile.existsSync()) {
-    final pkgConfigYaml = loadYamlChecked(
+    final pkgConfigYaml = loadYamlOrdered(
       yamlFile.readAsStringSync(),
       sourceUrl: relativeFilePath,
     );
@@ -76,7 +76,8 @@ Map yamlMapOrNull(String rootDir, String relativeFilePath) {
 
 /// Returns [source] parsed as Yaml, but tries to convert thrown
 /// [y.YamlException] instances to [ParsedYamlException] instances.
-Object loadYamlChecked(String source, {dynamic sourceUrl}) {
+// TODO: rename this to `loadYamlChecked` – more accurate
+Object loadYamlOrdered(String source, {dynamic sourceUrl}) {
   try {
     return y.loadYaml(source, sourceUrl: sourceUrl);
   } on y.YamlException catch (e) {

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   path: ^1.4.1
   pub_semver: ^1.3.2
   pubspec_parse: ^0.1.0
-  yaml: ^2.1.12
+  yaml: ^2.2.0
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -26,7 +26,7 @@ PackageConfig _parse(map) => PackageConfig.parse(
     _dummyPubspec,
     map is YamlMap
         ? map
-        : loadYamlChecked(
+        : loadYamlOrdered(
             _encodeJson(map),
           ) as Map);
 
@@ -50,7 +50,7 @@ void main() {
   });
 
   test('valid example', () {
-    final monoYaml = loadYamlChecked(_testConfig1) as Map;
+    final monoYaml = loadYamlOrdered(_testConfig1) as Map;
 
     final config = _parse(monoYaml);
 

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -113,7 +113,7 @@ line 4, column 7: Must be a map or a string.
       _expectParseThrows(
         {'dart': null},
         r'''
-line 2, column 10: Unsupported value for "dart". "dart" must be an array with at least one value.
+line 2, column 10: Unsupported value for "dart". The value for "dart" must be an array with at least one value.
   ╷
 2 │  "dart": null
   │          ^^^^
@@ -125,7 +125,7 @@ line 2, column 10: Unsupported value for "dart". "dart" must be an array with at
       _expectParseThrows(
         {'dart': []},
         r'''
-line 2, column 10: Unsupported value for "dart". "dart" must be an array with at least one value.
+line 2, column 10: Unsupported value for "dart". The value for "dart" must be an array with at least one value.
   ╷
 2 │  "dart": []
   │          ^^

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -7,31 +7,31 @@
 
 import 'dart:convert';
 
-import 'package:json_annotation/json_annotation.dart';
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+import 'shared.dart';
 
 final _dummyPubspec = Pubspec('_example');
 
 String _encodeJson(Object input) =>
     const JsonEncoder.withIndent(' ').convert(input);
 
-Matcher throwsCheckedFromJsonException(String prettyValue) => throwsA(
-      const TypeMatcher<CheckedFromJsonException>().having((e) {
-        final prettyValue = toParsedYamlExceptionOrNull(e).formattedMessage;
-        printOnFailure("r'''\n$prettyValue'''");
-        return prettyValue;
-      }, 'prettyPrint', prettyValue),
-    );
-
 PackageConfig _parse(map) => PackageConfig.parse(
-    'a', _dummyPubspec, loadYamlOrdered(_encodeJson(map)) as Map);
+    'a',
+    _dummyPubspec,
+    map is YamlMap
+        ? map
+        : loadYamlChecked(
+            _encodeJson(map),
+          ) as Map);
 
-void _expectParseThrows(Object content, String expectedError) => expect(
-    () => _parse(content), throwsCheckedFromJsonException(expectedError));
+void _expectParseThrows(Object content, String expectedError) =>
+    expect(() => _parse(content), throwsAParsedYamlException(expectedError));
 
 void main() {
   glyph.ascii = false;
@@ -50,9 +50,9 @@ void main() {
   });
 
   test('valid example', () {
-    final monoYaml = loadYamlOrdered(_testConfig1) as Map;
+    final monoYaml = loadYamlChecked(_testConfig1) as Map;
 
-    final config = PackageConfig.parse('a', _dummyPubspec, monoYaml);
+    final config = _parse(monoYaml);
 
     expect(config.sdks, unorderedEquals(['dev', 'stable', '1.23.0']));
 
@@ -70,7 +70,7 @@ void main() {
       expect(config.sdks, isEmpty);
     });
 
-    test('fun', () {
+    test('stage items must be a map', () {
       _expectParseThrows(
         {
           'stages': [
@@ -80,17 +80,31 @@ void main() {
           ]
         },
         r'''
-line 1, column 1: "dart" is missing.
+line 4, column 14: Each item within a stage must be a map.
   ╷
-1 │ ┌ {
-2 │ │  "stages": [
-3 │ │   {
-4 │ │    "format": [
+4 │      "format": [
+  │ ┌──────────────^
 5 │ │     "dartfmt"
-6 │ │    ]
-7 │ │   }
-8 │ │  ]
-9 │ └ }
+6 │ └    ]
+  ╵''',
+      );
+    });
+
+    test('group items must be instances of map or string', () {
+      _expectParseThrows(
+        loadYaml(r'''
+stages:
+- smoke_test:
+  - group:
+    - [dartfmt]
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+    dart: dev
+'''),
+        r'''
+line 4, column 7: Must be a map or a string.
+  ╷
+4 │     - [dartfmt]
+  │       ^^^^^^^^^
   ╵''',
       );
     });
@@ -179,6 +193,26 @@ line 7, column 9: Unsupported value for "a". Stages must be a list of maps with 
   │ ┌─────────^
 8 │ │   }
   │ └──^
+  ╵''',
+      );
+    });
+
+    test('Stages tasks must be a list', () {
+      final monoYaml = loadYaml('''
+stages:
+- smoke_test:
+  - description: 'bob'
+    group: funky
+    dart: dev
+''');
+
+      _expectParseThrows(
+        monoYaml,
+        r'''
+line 4, column 12: Unsupported value for "group". expected a list of tasks
+  ╷
+4 │     group: funky
+  │            ^^^^^
   ╵''',
       );
     });

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -181,7 +181,7 @@ name: pkg_name
       );
     });
 
-    test('throws if the previous config doesn\'t match', () async {
+    test("throws if the previous config doesn't match", () async {
       await d.file(travisFileName, '').create();
       await d.dir('tool', [
         d.file('travis.sh', ''),
@@ -469,9 +469,12 @@ name: pkg_a
 
     expect(
       testGenerateTravisConfig,
-      throwsAParsedYamlException(
-        contains('"dart" is missing.'),
-      ),
+      throwsAParsedYamlException(r'''
+line 3, column 5 of pkg_a/mono_pkg.yaml: Each item within a stage must be a map.
+  ╷
+3 │     - dartfmt
+  │     ^^^^^^^^^
+  ╵'''),
     );
   });
 
@@ -1021,26 +1024,19 @@ stages:
       });
     });
 
-    group('invalid travis value type', () {
-      for (var invalidContent in [
-        true,
-        5,
-        'string',
-        ['array']
-      ]) {
-        test(invalidContent.runtimeType.toString(), () async {
-          final monoConfigContent = toYaml({'travis': invalidContent});
-          await populateConfig(monoConfigContent);
+    test('travis value must be a Map', () async {
+      final monoConfigContent = toYaml({'travis': 5});
+      await populateConfig(monoConfigContent);
 
-          expect(
-            testGenerateTravisConfig,
-            throwsAParsedYamlException(
-              contains(
-                  'Unsupported value for "travis". `travis` must be a Map.'),
-            ),
-          );
-        });
-      }
+      expect(
+        testGenerateTravisConfig,
+        throwsAParsedYamlException(r'''
+line 1, column 9 of mono_repo.yaml: Unsupported value for "travis". `travis` must be a Map.
+  ╷
+1 │ travis: 5
+  │         ^
+  ╵'''),
+      );
     });
 
     group('invalid travis keys', () {

--- a/mono_repo/test/travis_command_test.dart
+++ b/mono_repo/test/travis_command_test.dart
@@ -460,7 +460,7 @@ cache:
       d.file(monoPkgFileName, r'''
 stages:
   - format:
-    - dartfmt
+    - dartfmt:
 '''),
       d.file('pubspec.yaml', '''
 name: pkg_a
@@ -469,11 +469,11 @@ name: pkg_a
 
     expect(
       testGenerateTravisConfig,
-      throwsAParsedYamlException(r'''
-line 3, column 5 of pkg_a/mono_pkg.yaml: Each item within a stage must be a map.
+      throwsAParsedYamlException('''
+line 3, column 7 of ${p.normalize('pkg_a/mono_pkg.yaml')}: A "dart" key is required.
   ╷
-3 │     - dartfmt
-  │     ^^^^^^^^^
+3 │     - dartfmt:
+  │       ^^^^^^^^
   ╵'''),
     );
   });

--- a/mono_repo/test/yaml_write_test.dart
+++ b/mono_repo/test/yaml_write_test.dart
@@ -52,10 +52,10 @@ void main() {
   });
 
   test('config file', () {
-    final decoded = loadYamlChecked(testConfig2);
+    final decoded = loadYamlOrdered(testConfig2);
     final output = toYaml(decoded);
     printOnFailure(['# start yaml', output, '# end yaml'].join('\n'));
-    final roundTrip = loadYamlChecked(output);
+    final roundTrip = loadYamlOrdered(output);
     expect(roundTrip, decoded);
   });
 }
@@ -64,7 +64,7 @@ void _asciiTest(List<int> bytes) {
   test(bytes.toString(), () {
     final source = ascii.decode(bytes);
     final output = toYaml(source);
-    final yaml = loadYamlChecked(output);
+    final yaml = loadYamlOrdered(output);
     expect(yaml, source, reason: bytes.toString());
   });
 }
@@ -105,7 +105,7 @@ void _testRoundTripCore(Object source, {String expectedEncoding}) {
   test(testTitle, () {
     final output = toYaml(source);
     printOnFailure(['# start yaml', output, '# end yaml'].join('\n'));
-    final yaml = loadYamlChecked(output);
+    final yaml = loadYamlOrdered(output);
     expect(yaml, source);
     if (expectedEncoding != null) {
       expect(output, expectedEncoding);

--- a/mono_repo/test/yaml_write_test.dart
+++ b/mono_repo/test/yaml_write_test.dart
@@ -52,10 +52,10 @@ void main() {
   });
 
   test('config file', () {
-    final decoded = loadYamlOrdered(testConfig2);
+    final decoded = loadYamlChecked(testConfig2);
     final output = toYaml(decoded);
     printOnFailure(['# start yaml', output, '# end yaml'].join('\n'));
-    final roundTrip = loadYamlOrdered(output);
+    final roundTrip = loadYamlChecked(output);
     expect(roundTrip, decoded);
   });
 }
@@ -64,7 +64,7 @@ void _asciiTest(List<int> bytes) {
   test(bytes.toString(), () {
     final source = ascii.decode(bytes);
     final output = toYaml(source);
-    final yaml = loadYamlOrdered(output);
+    final yaml = loadYamlChecked(output);
     expect(yaml, source, reason: bytes.toString());
   });
 }
@@ -105,7 +105,7 @@ void _testRoundTripCore(Object source, {String expectedEncoding}) {
   test(testTitle, () {
     final output = toYaml(source);
     printOnFailure(['# start yaml', output, '# end yaml'].join('\n'));
-    final yaml = loadYamlOrdered(output);
+    final yaml = loadYamlChecked(output);
     expect(yaml, source);
     if (expectedEncoding != null) {
       expect(output, expectedEncoding);


### PR DESCRIPTION
Update logic to handle cases where yaml maps need to be modified so that
robust error logging keeps working

Also improved testing and implementation in a number of extra error cases