### PR TITLE
2 fixes

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2-dev
 name: Dart CI
 
 on:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -3,7 +3,7 @@ name: Dart CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [$default-branch]
   pull_request:
 
 defaults:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2-dev
 language: dart
 
 jobs:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0-beta.2-dev
+
+* Support `stable` as a valid Dart SDK label.
+
 ## 3.1.0-beta.1
 
 * Fix self-validate logic.

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.1.0-beta.2-dev
 
-* Support `stable` as a valid Dart SDK label.
+* GitHub actions:
+  * Support `stable` as a valid Dart SDK label.
+  * Use `[$default-branch]` instead of `[master]`.
 
 ## 3.1.0-beta.1
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -112,7 +112,9 @@ extension on CIJobEntry {
 
     if (realVersion != null) {
       if (realVersion.isPreRelease) {
-        throw UnsupportedError('Not sure how to party on `${job.sdk}`.');
+        throw UnsupportedError(
+          'Unsupported Dart SDK configuration: `${job.sdk}`.',
+        );
       }
       withMap = {
         'release-channel': 'stable',
@@ -120,8 +122,12 @@ extension on CIJobEntry {
       };
     } else if (job.sdk == 'dev') {
       withMap = {'release-channel': 'dev'};
+    } else if (job.sdk == 'stable') {
+      withMap = {'release-channel': 'stable', 'version': 'latest'};
     } else {
-      throw UnsupportedError('Not sure how to party on `${job.sdk}`.');
+      throw UnsupportedError(
+        'Unsupported Dart SDK configuration: `${job.sdk}`.',
+      );
     }
 
     final map = {

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -24,7 +24,7 @@ ${createdWith()}${toYaml({'name': 'Dart CI'})}
 
 on:
   push:
-    branches: [ master ]
+    branches: [\$default-branch]
   pull_request:
 
 defaults:

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.1.0-beta.1';
+const packageVersion = '3.1.0-beta.2-dev';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 3.1.0-beta.1
+version: 3.1.0-beta.2-dev
 homepage: https://github.com/google/mono_repo.dart
 
 environment:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2-dev
 
 # Support built in commands on windows out of the box.
 function pub() {


### PR DESCRIPTION
- Support `stable` as a valid SDK label
- GitHub: Use [$default-branch] instead of master
