### PR TITLE
GitHub Actions: cache pub dependencies on linux and mac

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,6 +19,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo;commands:command"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
@@ -32,6 +42,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKGS: mono_repo, test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`]"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo-test_pkg;commands:dartfmt-dartanalyzer_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo-test_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
@@ -45,6 +65,16 @@ jobs:
     name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.7.0;packages:mono_repo;commands:dartanalyzer_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.7.0;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;dart:2.7.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: stable
@@ -59,6 +89,16 @@ jobs:
     name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.7.0;packages:mono_repo;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.7.0;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;dart:2.7.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: stable
@@ -87,6 +127,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
@@ -113,6 +163,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: test_pkg; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:test_pkg;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:test_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Improved error messages for invalid configuration.
 * Add support for the github `env` key in repo level configuration for setting
   up global environment variables.
+* Support caching pub dependencies between builds – but only on Linux and MacOS
+  for now.
 
 ## 3.1.0-beta.4
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -173,12 +173,17 @@ extension on CIJobEntry {
       _jobName(packages),
       _githubJobOs,
       job.sdk,
-      {
-        '$ciScriptPath ${commands.join(' ')}': {
-          'PKGS': packages.join(' '),
-          'TRAVIS_OS_NAME': job.os,
-        }
-      },
+      [
+        _CommandEntry(
+          '$ciScriptPath ${commands.join(' ')}',
+          env: {
+            'PKGS': packages.join(' '),
+            'TRAVIS_OS_NAME': job.os,
+          },
+        )
+      ],
+      packages: packages,
+      commandNames: commands,
     );
   }
 }
@@ -222,28 +227,95 @@ Map<String, dynamic> _createDartSetup(String sdk) {
   return map;
 }
 
-Map<String, dynamic> _githubJobYaml(String jobName, String jobOs,
-        String dartVersion, Map<String, Map<String, dynamic>> runCommands) =>
+Map<String, dynamic> _githubJobYaml(
+  String jobName,
+  String jobOs,
+  String dartVersion,
+  List<_CommandEntry> runCommands, {
+  List<String> packages,
+  List<String> commandNames,
+}) =>
     {
       'name': jobName,
       'runs-on': jobOs,
       'steps': [
+        ..._cacheEntries(
+          jobOs,
+          dartVersion,
+          packages: packages,
+          commandNames: commandNames,
+        ),
         _createDartSetup(dartVersion),
         {'run': 'dart --version'},
         {'uses': 'actions/checkout@v2'},
-        for (var command in runCommands.entries)
-          {
-            if (command.value != null && command.value.isNotEmpty)
-              'env': command.value,
-            'run': command.key
-          },
+        for (var command in runCommands) command.runContent,
       ],
     };
 
-Map<String, dynamic> _selfValidateTaskConfig() =>
-    _githubJobYaml(selfValidateJobName, 'ubuntu-latest', 'stable', {
-      for (var command in selfValidateCommands) command: null,
-    });
+class _CommandEntry {
+  final String run;
+  final Map<String, String> env;
+
+  _CommandEntry(
+    this.run, {
+    this.env,
+  });
+
+  Map<String, dynamic> get runContent => {
+        if (env != null && env.isNotEmpty) 'env': env,
+        'run': run,
+      };
+}
+
+List<Map<String, dynamic>> _cacheEntries(
+  String jobOs,
+  String dartVersion, {
+  List<String> packages,
+  List<String> commandNames,
+}) {
+  final cacheKeyParts = [
+    'os:$jobOs',
+    'pub-cache-hosted',
+    'dart:$dartVersion',
+    if (packages != null && packages.isNotEmpty)
+      'packages:${packages.join('-')}',
+    if (commandNames != null && commandNames.isNotEmpty)
+      'commands:${commandNames.join('-')}'
+  ];
+
+  final restoreKeys = [
+    for (var i = cacheKeyParts.length - 1; i > 0; i--)
+      cacheKeyParts.take(i).join(';')
+  ];
+
+  // Just caching the `hosted` directory because caching git dependencies or
+  // activated packages can cause problems.
+  const pubCacheHosted = '~/.pub-cache/hosted';
+
+  return [
+    // TODO: Support windows caching google/mono_repo.dart#267
+    // Sadly, there seems to be no clean way to support windows - yet
+    if (!jobOs.startsWith('windows'))
+      {
+        'name': 'Cache Pub hosted dependencies',
+        'uses': 'actions/cache@v2',
+        'with': {
+          'path': pubCacheHosted,
+          'key': cacheKeyParts.join(';'),
+          'restore-keys': restoreKeys.join('\n'),
+        }
+      }
+  ];
+}
+
+Map<String, dynamic> _selfValidateTaskConfig() => _githubJobYaml(
+      selfValidateJobName,
+      'ubuntu-latest',
+      'stable',
+      [
+        for (var command in selfValidateCommands) _CommandEntry(command),
+      ],
+    );
 
 /// Used as a place-holder so we can treat all jobs the same in certain
 /// workflows.

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:mono_repo/src/commands/ci_script/generate.dart';
@@ -53,15 +52,7 @@ name: sub_pkg
       String expectedOutputFileName,
     ) {
       final inputFile = File(p.join(d.sandbox, fileToVerify));
-
-      var sourceContent = inputFile.readAsStringSync();
-
-      if (Platform.isWindows) {
-        // Make things consistent on Windows
-        sourceContent =
-            LineSplitter.split(sourceContent).map((e) => '$e\r\n').join();
-      }
-
+      final sourceContent = inputFile.readAsStringSync();
       validateOutput(
         'readme_$expectedOutputFileName.txt',
         sourceContent,
@@ -72,7 +63,7 @@ name: sub_pkg
     validateFile(ciScriptPath, 'ci');
     validateFile(githubWorkflowFilePath('lint'), 'github_lints');
     validateFile(defaultGitHubWorkflowFilePath, 'github_defaults');
-  });
+  }, onPlatform: const {'windows': Skip('Many platform-specific differences')});
 }
 
 String _yamlWrap(String content) => '```yaml\n$content```';

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -19,6 +19,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -19,6 +19,14 @@ jobs:
     name: mono_repo self validate
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: stable
@@ -31,6 +39,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:dartanalyzer"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
@@ -44,6 +62,16 @@ jobs:
     name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `dartfmt -n --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:dartfmt"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev


### PR DESCRIPTION
Cache the `~/.pub_cache/hosted` directory using the `cache` action – https://github.com/marketplace/actions/cache

A cache `key` is generated that corresponds to the OS, Dart version, packages and commands used in each Job.

Windows is blocked – https://github.com/google/mono_repo.dart/issues/267a