### PR TITLE
Full stages support for github actions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -109,6 +109,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_0
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_005:
     name: "OS: windows; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
@@ -123,6 +127,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_0
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_006:
     name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -146,6 +154,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_0
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_007:
     name: "OS: windows; SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
@@ -159,6 +171,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_0
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_008:
     name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -183,6 +199,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_1
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_009:
     name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -206,6 +226,10 @@ jobs:
           PKGS: mono_repo
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_1
+    needs:
+      - job_001
+      - job_002
+      - job_003
   job_010:
     name: "OS: linux; SDK: dev; PKG: test_pkg; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -229,18 +253,11 @@ jobs:
           PKGS: test_pkg
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_2
-  job_011:
     needs:
       - job_001
       - job_002
       - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
+  job_011:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -251,3 +268,11 @@ jobs:
             "${CHAT_WEBHOOK_URL}"
         env:
           CHAT_WEBHOOK_URL: "${{ secrets.CHAT_WEBHOOK_URL }}"
+    needs:
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -260,7 +260,7 @@ jobs:
   job_011:
     name: Notify failure
     runs-on: ubuntu-latest
-    if: failure()
+    if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
     steps:
       - run: |
           curl -H "Content-Type: application/json" -X POST -d \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -260,7 +260,7 @@ jobs:
   job_011:
     name: Notify failure
     runs-on: ubuntu-latest
-    if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
+    if: failure()
     steps:
       - run: |
           curl -H "Content-Type: application/json" -X POST -d \

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.2.0
+# Created with package:mono_repo v3.3.0
 name: Dart CI
 on:
   push:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.2.0
+# Created with package:mono_repo v3.3.0
 language: dart
 
 jobs:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.0
+
+- Implemented proper support for `stages` in github actions. Jobs will now
+  be dependent on previous stages jobs. Conditional stages are also supported
+  in the same manner as travis was, see the README.md for more details.
+
 ## 3.2.0
 
 - Added support for `on_completion` jobs in github configuration, see the

--- a/mono_repo/README.md
+++ b/mono_repo/README.md
@@ -114,6 +114,15 @@ github:
           env:
             CHAT_WEBHOOK_URL: ${{ secrets.CHAT_WEBHOOK_URL }}
 
+  # You can customize stage ordering as well as make certain stages be
+  # conditional here, this is supported for all CI providers. The `if`
+  # condition should use the appropriate syntax for the provider it is being
+  # configured for.
+  stages:
+    - name: cron
+      # Only run this stage for scheduled cron jobs
+      if: github.event_name == 'schedule'
+
 # Enables Travis-CI - https://docs.travis-ci.com/
 # If you have no configuration, you can set the value to `true` or just leave it
 # empty.
@@ -163,6 +172,16 @@ stages:
     - dartfmt
   - unit_test:
     - test
+  # Example cron stage which will only run for scheduled jobs (here we run
+  # multiple OS configs for extra validation as an example).
+  #
+  # See the `mono_repo.yaml` example above for where this stage is specially
+  # configured.
+  - cron:
+    - test:
+      os:
+        - linux
+        - windows
 ```
 
 Running `mono_repo generate` in the root directory generates two or more files:

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -192,7 +192,7 @@ void logPackages(Iterable<PackageConfig> configs) {
 ///
 /// The [conditionalStages] are CI specific, as they use CI specific expression
 /// syntax.
-List<Object /*ConditionalStage|String*/ > calculateOrderedStages(
+List<String> calculateOrderedStages(
     RootConfig rootConfig, Map<String, ConditionalStage> conditionalStages) {
   // Convert the configs to a graph so we can run strongly connected components.
   final edges = <String, Set<String>>{};
@@ -252,7 +252,7 @@ List<Object /*ConditionalStage|String*/ > calculateOrderedStages(
 
         final matchingStage = conditionalStages[stageName];
 
-        return matchingStage?.toJson() ?? stageName;
+        return matchingStage.name ?? stageName;
       })
       .toList()
       .reversed

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -193,7 +193,9 @@ void logPackages(Iterable<PackageConfig> configs) {
 /// The [conditionalStages] are CI specific, as they use CI specific expression
 /// syntax.
 List<String> calculateOrderedStages(
-    RootConfig rootConfig, Map<String, ConditionalStage> conditionalStages) {
+  RootConfig rootConfig,
+  Map<String, ConditionalStage> conditionalStages,
+) {
   // Convert the configs to a graph so we can run strongly connected components.
   final edges = <String, Set<String>>{};
 

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -246,17 +246,8 @@ List<String> calculateOrderedStages(
     }
   }
 
-  final orderedStages = components
-      .map((c) {
-        final stageName = c.first;
-
-        final matchingStage = conditionalStages[stageName];
-
-        return matchingStage.name ?? stageName;
-      })
-      .toList()
-      .reversed
-      .toList();
+  final orderedStages =
+      components.map((c) => c.first).toList().reversed.toList();
 
   if (rootConfig.monoConfig.selfValidateStage != null &&
       !orderedStages.contains(rootConfig.monoConfig.selfValidateStage)) {

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -123,7 +123,7 @@ ${toYaml({'jobs': jobList})}
 }
 
 /// Lists all the jobs, setting their stage, environment, and script.
-Iterable<MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
+Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
   Iterable<HasStageName> jobs,
   Map<String, String> commandsToKeys,
   Set<String> mergeStages,
@@ -136,7 +136,7 @@ Iterable<MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
 
   String jobName(int jobNum) => 'job_${jobNum.toString().padLeft(3, '0')}';
 
-  MapEntryWithStage<String, Map<String, dynamic>> jobEntry(
+  _MapEntryWithStage<String, Map<String, dynamic>> jobEntry(
     Map<String, dynamic> content,
     String stage,
   ) {
@@ -144,7 +144,7 @@ Iterable<MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
     if (conditional != null) {
       content['if'] = conditional.ifCondition;
     }
-    return MapEntryWithStage(jobName(++count), content, stage);
+    return _MapEntryWithStage(jobName(++count), content, stage);
   }
 
   for (var job in jobs) {
@@ -395,7 +395,7 @@ class _SelfValidateJob implements HasStageName {
   _SelfValidateJob(this.stageName);
 }
 
-class MapEntryWithStage<K, V> implements MapEntry<K, V> {
+class _MapEntryWithStage<K, V> implements MapEntry<K, V> {
   @override
   final K key;
   @override
@@ -403,5 +403,5 @@ class MapEntryWithStage<K, V> implements MapEntry<K, V> {
 
   final String stageName;
 
-  MapEntryWithStage(this.key, this.value, this.stageName);
+  _MapEntryWithStage(this.key, this.value, this.stageName);
 }

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -13,6 +13,8 @@ import '../../user_exception.dart';
 import '../../yaml.dart';
 import '../ci_script/generate.dart';
 
+const _onCompletionStage = '_on_completion';
+
 Map<String, String> generateGitHubYml(
   RootConfig rootConfig,
   Map<String, String> commandsToKeys,
@@ -27,6 +29,9 @@ Map<String, String> generateGitHubYml(
   }
 
   final allJobStages = {for (var job in jobs) job.stageName};
+  final orderedStages = calculateOrderedStages(
+      rootConfig, rootConfig.monoConfig.githubConditionalStages)
+    ..add(_onCompletionStage);
 
   final output = <String, String>{};
 
@@ -40,14 +45,32 @@ Map<String, String> generateGitHubYml(
         'Should not get here – duplicate workflow "$fileName".',
       );
     }
-    final jobList = Map.fromEntries(
-      _listJobs(
-        myJobs,
-        commandsToKeys,
-        rootConfig.monoConfig.mergeStages,
-        rootConfig.monoConfig.github.onCompletion,
-      ),
-    );
+    final allJobs = _listJobs(
+      myJobs,
+      commandsToKeys,
+      rootConfig.monoConfig.mergeStages,
+      rootConfig.monoConfig.github.onCompletion,
+    ).toList()
+      ..sort((a, b) => orderedStages
+          .indexOf(a.stageName)
+          .compareTo(orderedStages.indexOf(b.stageName)));
+
+    var currStageJobs = <String>{};
+    var prevStageJobs = <String>{};
+    String currStageName;
+    for (var job in allJobs) {
+      if (job.stageName != currStageName) {
+        currStageName = job.stageName;
+        prevStageJobs = currStageJobs;
+        currStageJobs = {};
+      }
+      currStageJobs.add(job.key);
+      if (prevStageJobs.isNotEmpty) {
+        job.value['needs'] = prevStageJobs;
+      }
+    }
+
+    final jobList = Map.fromEntries(allJobs);
 
     output[fileName] = '''
 $createdWith
@@ -98,7 +121,7 @@ ${toYaml({'jobs': jobList})}
 }
 
 /// Lists all the jobs, setting their stage, environment, and script.
-Iterable<MapEntry<String, Map<String, dynamic>>> _listJobs(
+Iterable<MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
   Iterable<HasStageName> jobs,
   Map<String, String> commandsToKeys,
   Set<String> mergeStages,
@@ -110,14 +133,15 @@ Iterable<MapEntry<String, Map<String, dynamic>>> _listJobs(
 
   String jobName(int jobNum) => 'job_${jobNum.toString().padLeft(3, '0')}';
 
-  MapEntry<String, Map<String, dynamic>> jobEntry(
+  MapEntryWithStage<String, Map<String, dynamic>> jobEntry(
     Map<String, dynamic> content,
+    String stage,
   ) =>
-      MapEntry(jobName(++count), content);
+      MapEntryWithStage(jobName(++count), content, stage);
 
   for (var job in jobs) {
     if (job is _SelfValidateJob) {
-      yield jobEntry(_selfValidateTaskConfig());
+      yield jobEntry(_selfValidateTaskConfig(), job.stageName);
       continue;
     }
 
@@ -142,21 +166,19 @@ Iterable<MapEntry<String, Map<String, dynamic>>> _listJobs(
 
     if (mergeStages.contains(first.job.stageName)) {
       final packages = entry.value.map((t) => t.job.package).toList();
-      yield jobEntry(first.jobYaml(packages));
+      yield jobEntry(first.jobYaml(packages), first.job.stageName);
     } else {
-      yield* entry.value.map((e) => jobEntry(e.jobYaml()));
+      yield* entry.value.map((e) => jobEntry(e.jobYaml(), e.job.stageName));
     }
   }
 
   // Generate the jobs that run on completion of all other jobs, by adding the
   // appropriate `needs` config to each.
   if (onCompletionJobs != null && onCompletionJobs.isNotEmpty) {
-    final needs = List.generate(count, (i) => jobName(i + 1));
     for (var jobConfig in onCompletionJobs) {
       yield jobEntry({
-        'needs': needs,
         ...jobConfig,
-      });
+      }, _onCompletionStage);
     }
   }
 }
@@ -363,4 +385,15 @@ class _SelfValidateJob implements HasStageName {
   final String stageName;
 
   _SelfValidateJob(this.stageName);
+}
+
+class MapEntryWithStage<K, V> implements MapEntry<K, V> {
+  @override
+  final K key;
+  @override
+  final V value;
+
+  final String stageName;
+
+  MapEntryWithStage(this.key, this.value, this.stageName);
 }

--- a/mono_repo/lib/src/github_config.dart
+++ b/mono_repo/lib/src/github_config.dart
@@ -21,6 +21,9 @@ class GitHubConfig {
   // TODO: needed until google/json_serializable.dart#747 is fixed
   String get cron => throw UnimplementedError();
 
+  // Either Strings or Maps are supported here.
+  final List<dynamic> stages;
+
   final Map<String, GitHubWorkflow> workflows;
 
   GitHubConfig(
@@ -28,6 +31,7 @@ class GitHubConfig {
     Map<String, dynamic> on,
     this.onCompletion,
     String cron,
+    this.stages,
     this.workflows,
   ) : on = _parseOn(on, cron) {
     if (workflows != null) {

--- a/mono_repo/lib/src/github_config.g.dart
+++ b/mono_repo/lib/src/github_config.g.dart
@@ -10,8 +10,14 @@ part of 'github_config.dart';
 
 GitHubConfig _$GitHubConfigFromJson(Map json) {
   return $checkedNew('GitHubConfig', json, () {
-    $checkKeys(json,
-        allowedKeys: const ['env', 'on', 'on_completion', 'cron', 'workflows']);
+    $checkKeys(json, allowedKeys: const [
+      'env',
+      'on',
+      'on_completion',
+      'cron',
+      'stages',
+      'workflows'
+    ]);
     final val = GitHubConfig(
       $checkedConvert(
           json,
@@ -34,6 +40,7 @@ GitHubConfig _$GitHubConfigFromJson(Map json) {
                   ))
               ?.toList()),
       $checkedConvert(json, 'cron', (v) => v as String),
+      $checkedConvert(json, 'stages', (v) => v as List),
       $checkedConvert(
           json,
           'workflows',

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -86,7 +86,7 @@ class MonoConfig {
       prettyAnsi: prettyAnsi,
       pubAction: pubAction,
       selfValidateStage: selfValidateStage,
-      travis: travis.map((k, v) => MapEntry(k as String, v)),
+      travis: travis.map((k, v) => MapEntry(k as String, v))..remove('stages'),
       github: GitHubConfig.fromJson(github),
     );
   }

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -78,8 +78,8 @@ class MonoConfig {
     final githubConditionalStages = _readConditionalStages(github);
     final travisConditionalStages = _readConditionalStages(travis);
     // We are done with these values now
-    github.remove('stages');
-    travis.remove('stages');
+    github = Map.of(github)..remove('stages');
+    travis = Map.of(travis)..remove('stages');
 
     return MonoConfig._(
       ci: ci,

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -77,9 +77,6 @@ class MonoConfig {
 
     final githubConditionalStages = _readConditionalStages(github);
     final travisConditionalStages = _readConditionalStages(travis);
-    // We are done with these values now
-    github = Map.of(github)..remove('stages');
-    travis = Map.of(travis)..remove('stages');
 
     return MonoConfig._(
       ci: ci,

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -34,7 +34,7 @@ const _allowedPubActions = {
 
 class MonoConfig {
   final Set<CI> ci;
-  final Map<String, ConditionalStage> conditionalStages;
+  final Map<String, ConditionalStage> travisConditionalStages;
   final Set<String> mergeStages;
   final bool prettyAnsi;
   final String pubAction;
@@ -44,7 +44,7 @@ class MonoConfig {
 
   MonoConfig._({
     @required Set<CI> ci,
-    @required this.conditionalStages,
+    @required this.travisConditionalStages,
     @required this.mergeStages,
     @required this.prettyAnsi,
     @required this.pubAction,
@@ -73,14 +73,14 @@ class MonoConfig {
       );
     }
 
-    final conditionalStages = <String, ConditionalStage>{};
+    final travisConditionalStages = <String, ConditionalStage>{};
     final rawStageValue = travis['stages'];
     if (rawStageValue != null) {
       if (rawStageValue is List) {
         for (var item in rawStageValue) {
           if (item is Map || item is String) {
             final stage = ConditionalStage.fromJson(item);
-            if (conditionalStages.containsKey(stage.name)) {
+            if (travisConditionalStages.containsKey(stage.name)) {
               throw CheckedFromJsonException(
                 travis,
                 'stages',
@@ -88,7 +88,7 @@ class MonoConfig {
                 '`${stage.name}` appears more than once.',
               );
             }
-            conditionalStages[stage.name] = stage;
+            travisConditionalStages[stage.name] = stage;
           } else {
             throw CheckedFromJsonException(
               travis,
@@ -110,7 +110,7 @@ class MonoConfig {
 
     return MonoConfig._(
       ci: ci,
-      conditionalStages: conditionalStages,
+      travisConditionalStages: travisConditionalStages,
       mergeStages: mergeStages,
       prettyAnsi: prettyAnsi,
       pubAction: pubAction,

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.2.0';
+const packageVersion = '3.3.0';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 3.2.0
+version: 3.3.0
 repository: https://github.com/google/mono_repo.dart
 
 environment:

--- a/mono_repo/test/github_command_test.dart
+++ b/mono_repo/test/github_command_test.dart
@@ -19,7 +19,7 @@ void main() {
         'github': {'not_supported': 5}
       },
       r'''
-line 2, column 3 of mono_repo.yaml: Unrecognized keys: [not_supported]; supported keys: [env, on, on_completion, cron, workflows]
+line 2, column 3 of mono_repo.yaml: Unrecognized keys: [not_supported]; supported keys: [env, on, on_completion, cron, stages, workflows]
   ╷
 2 │   not_supported: 5
   │   ^^^^^^^^^^^^^

--- a/mono_repo/test/github_command_test.dart
+++ b/mono_repo/test/github_command_test.dart
@@ -432,8 +432,11 @@ Future<void> _testBadConfigWithYamlException(
 }
 
 Future<void> _testBadConfigWithUserException(
-    Object monoRepoYaml, Object expectedMessage,
-    {Object expectedDetails, Object printMatcher}) async {
+  Object monoRepoYaml,
+  Object expectedMessage, {
+  Object expectedDetails,
+  Object printMatcher,
+}) async {
   final monoConfigContent = toYaml(monoRepoYaml);
   await populateConfig(monoConfigContent);
   expect(

--- a/mono_repo/test/github_command_test.dart
+++ b/mono_repo/test/github_command_test.dart
@@ -14,7 +14,7 @@ void main() {
 
   test(
     'only supported keys',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {'not_supported': 5}
       },
@@ -29,7 +29,7 @@ line 2, column 3 of mono_repo.yaml: Unrecognized keys: [not_supported]; supporte
 
   test(
     '"on" must be a Map',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {'on': 'not a map'}
       },
@@ -44,7 +44,7 @@ line 2, column 7 of mono_repo.yaml: Unsupported value for "on". type 'String' is
 
   test(
     'no cron with on',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {'cron': 'some value', 'on': {}}
       },
@@ -59,7 +59,7 @@ line 2, column 9 of mono_repo.yaml: Unsupported value for "cron". Cannot set `cr
 
   test(
     'env must be a map',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {'env': 'notAmap'},
       },
@@ -74,7 +74,7 @@ line 2, column 8 of mono_repo.yaml: Unsupported value for "env". type 'String' i
 
   test(
     '"on_completion" does not allow setting "needs"',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'on_completion': [
@@ -93,13 +93,100 @@ line 3, column 5 of mono_repo.yaml: Unsupported value for "on_completion". Canno
     ),
   );
 
+  test(
+    'stages config only accepts a list',
+    () => _testBadConfigWithYamlException(
+      {
+        'github': {'stages': 5}
+      },
+      r'''
+line 2, column 11 of mono_repo.yaml: Unsupported value for "stages". `stages` must be an array.
+  ╷
+2 │   stages: 5
+  │           ^
+  ╵''',
+    ),
+  );
+
+  test(
+    'stages config only accepts a list of Strings or Maps',
+    () => _testBadConfigWithYamlException(
+      {
+        'github': {
+          'stages': [5]
+        }
+      },
+      r'''
+line 3, column 5 of mono_repo.yaml: Unsupported value for "stages". All values must be String or Map instances.
+  ╷
+3 │     - 5
+  │     ^^^
+  ╵''',
+    ),
+  );
+
+  test(
+    'stages only accepts known stage names',
+    () => _testBadConfigWithUserException(
+      {
+        'github': {
+          'stages': ['missing']
+        }
+      },
+      'Error parsing mono_repo.yaml',
+      expectedDetails: r'''
+One or more stage was referenced in `mono_repo.yaml` that do not exist in any `mono_pkg.yaml` files: `missing`.''',
+      // In this case there is some output printed before we get to the user
+      // exception, but it isn't relevant.
+      printMatcher: anything,
+    ),
+  );
+
+  test(
+    'conditional stages only accept string if values',
+    () => _testBadConfigWithYamlException(
+      {
+        'github': {
+          'stages': [
+            {'name': 'foo', 'if': 1}
+          ],
+        }
+      },
+      r'''
+line 4, column 11 of mono_repo.yaml: Unsupported value for "if". type 'int' is not a subtype of type 'String' in type cast
+  ╷
+4 │       if: 1
+  │           ^
+  ╵''',
+    ),
+  );
+
+  test(
+    'conditional stages throw for unrecognized keys',
+    () => _testBadConfigWithYamlException(
+      {
+        'github': {
+          'stages': [
+            {'foo': 'bar'}
+          ],
+        }
+      },
+      r'''
+line 3, column 7 of mono_repo.yaml: Unrecognized keys: [foo]; supported keys: [name, if]
+  ╷
+3 │     - foo: bar
+  │       ^^^
+  ╵''',
+    ),
+  );
+
   group('workflows', _testWorkflows);
 }
 
 void _testWorkflows() {
   test(
     'must be a map',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {'workflows': 'some value'}
       },
@@ -114,7 +201,7 @@ line 2, column 14 of mono_repo.yaml: Unsupported value for "workflows". type 'St
 
   test(
     'must have required keys',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {'bob': {}}
@@ -131,7 +218,7 @@ line 3, column 10 of mono_repo.yaml: Required keys are missing: name, stages.
 
   test(
     'cannot have extra keys',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -154,7 +241,7 @@ line 7, column 7 of mono_repo.yaml: Unrecognized keys: [extra]; supported keys: 
 
   test(
     'stages cannot be empty',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -176,7 +263,7 @@ line 5, column 15 of mono_repo.yaml: Unsupported value for "stages". Cannot be e
 
   test(
     'stages cannot have null values',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -198,7 +285,7 @@ line 6, column 9 of mono_repo.yaml: Unsupported value for "stages". Stage values
 
   test(
     'workflows cannot have the default key `$defaultGitHubWorkflowFileName`',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -223,7 +310,7 @@ line 3, column 5 of mono_repo.yaml: Unsupported value for "workflows". Cannot de
   test(
     'workflows cannot have the same name as the default '
     'workflow `$defaultGitHubWorkflowName`',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -272,7 +359,7 @@ line 4, column 13 of mono_repo.yaml: Unsupported value for "name". Cannot be the
 
   test(
     'two workflows cannot have the same stage',
-    () => _testBadConfig(
+    () => _testBadConfigWithYamlException(
       {
         'github': {
           'workflows': {
@@ -304,7 +391,7 @@ line 3, column 5 of mono_repo.yaml: Unsupported value for "workflows". Stage "st
 
   test(
     'two workflows cannot have the same name',
-    () => _testBadConfig({
+    () => _testBadConfigWithYamlException({
       'github': {
         'workflows': {
           'alice': {
@@ -332,7 +419,7 @@ line 3, column 5 of mono_repo.yaml: Unsupported value for "workflows". Workflows
   );
 }
 
-Future<void> _testBadConfig(
+Future<void> _testBadConfigWithYamlException(
   Object monoRepoYaml,
   Object expectedParsedYaml,
 ) async {
@@ -341,5 +428,16 @@ Future<void> _testBadConfig(
   expect(
     testGenerateGitHubConfig,
     throwsAParsedYamlException(expectedParsedYaml),
+  );
+}
+
+Future<void> _testBadConfigWithUserException(
+    Object monoRepoYaml, Object expectedMessage,
+    {Object expectedDetails, Object printMatcher}) async {
+  final monoConfigContent = toYaml(monoRepoYaml);
+  await populateConfig(monoConfigContent);
+  expect(
+    () => testGenerateGitHubConfig(printMatcher: printMatcher),
+    throwsUserExceptionWith(expectedMessage, details: expectedDetails),
   );
 }

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -124,6 +124,15 @@ github:
           env:
             CHAT_WEBHOOK_URL: ${{ secrets.CHAT_WEBHOOK_URL }}
 
+  # You can customize stage ordering as well as make certain stages be
+  # conditional here, this is supported for all CI providers. The `if`
+  # condition should use the appropriate syntax for the provider it is being
+  # configured for.
+  stages:
+    - name: cron
+      # Only run this stage for scheduled cron jobs
+      if: github.event_name == 'schedule'
+
 # Enables Travis-CI - https://docs.travis-ci.com/
 # If you have no configuration, you can set the value to `true` or just leave it
 # empty.
@@ -160,4 +169,14 @@ stages:
     - dartfmt
   - unit_test:
     - test
+  # Example cron stage which will only run for scheduled jobs (here we run
+  # multiple OS configs for extra validation as an example).
+  #
+  # See the `mono_repo.yaml` example above for where this stage is specially
+  # configured.
+  - cron:
+    - test:
+      os:
+        - linux
+        - windows
 ''';

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -40,6 +40,48 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test
   job_002:
+    name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: sub_pkg
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test
+    if: "github.event_name == 'schedule'"
+    needs:
+      - job_001
+  job_003:
+    name: "OS: windows; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: sub_pkg
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test
+    if: "github.event_name == 'schedule'"
+    needs:
+      - job_001
+  job_004:
     name: Notify failure
     runs-on: ubuntu-latest
     if: failure()
@@ -51,4 +93,5 @@ jobs:
         env:
           CHAT_WEBHOOK_URL: "${{ secrets.CHAT_WEBHOOK_URL }}"
     needs:
-      - job_001
+      - job_002
+      - job_003

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -40,8 +40,6 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test
   job_002:
-    needs:
-      - job_001
     name: Notify failure
     runs-on: ubuntu-latest
     if: failure()
@@ -52,3 +50,5 @@ jobs:
             "${CHAT_WEBHOOK_URL}"
         env:
           CHAT_WEBHOOK_URL: "${{ secrets.CHAT_WEBHOOK_URL }}"
+    needs:
+      - job_001

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -83,10 +83,6 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartfmt
   job_004:
-    needs:
-      - job_001
-      - job_002
-      - job_003
     name: Notify failure
     runs-on: ubuntu-latest
     if: failure()
@@ -97,3 +93,7 @@ jobs:
             "${CHAT_WEBHOOK_URL}"
         env:
           CHAT_WEBHOOK_URL: "${{ secrets.CHAT_WEBHOOK_URL }}"
+    needs:
+      - job_001
+      - job_002
+      - job_003

--- a/mono_repo/test/script_integration_outputs/readme_travis.txt
+++ b/mono_repo/test/script_integration_outputs/readme_travis.txt
@@ -29,10 +29,23 @@ jobs:
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test
+    - stage: cron
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      dart: dev
+      os: linux
+      env: PKGS="sub_pkg"
+      script: tool/ci.sh test
+    - stage: cron
+      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      dart: dev
+      os: windows
+      env: PKGS="sub_pkg"
+      script: tool/ci.sh test
 
 stages:
   - analyze
   - unit_test
+  - cron
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.2.0
+# Created with package:mono_repo v3.3.0
 
 # Support built in commands on windows out of the box.
 function pub() {


### PR DESCRIPTION
Closes https://github.com/google/mono_repo.dart/issues/273

Adds a `stages` key to the `github` config which allows configuring stage ordering and conditions in the same way as the key under the `travis` config.

Respects stage ordering by adding `needs` on all jobs from the previous stage.