### PR TITLE
Generate prettier titles for jobs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   job_001:
-    name: "linux; Dart dev; PKG: mono_repo; `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
+    name: "smoke_test; linux; Dart dev; PKG: mono_repo; `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -39,7 +39,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh command
   job_002:
-    name: "linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
+    name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -62,7 +62,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartfmt dartanalyzer_0
   job_003:
-    name: "linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
+    name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -86,7 +86,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_1
   job_004:
-    name: "linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -114,7 +114,7 @@ jobs:
       - job_002
       - job_003
   job_005:
-    name: "windows; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -132,7 +132,7 @@ jobs:
       - job_002
       - job_003
   job_006:
-    name: "linux; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -159,7 +159,7 @@ jobs:
       - job_002
       - job_003
   job_007:
-    name: "windows; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -176,7 +176,7 @@ jobs:
       - job_002
       - job_003
   job_008:
-    name: "linux; Dart 2.7.0; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -204,7 +204,7 @@ jobs:
       - job_002
       - job_003
   job_009:
-    name: "linux; Dart dev; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart dev; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -231,7 +231,7 @@ jobs:
       - job_002
       - job_003
   job_010:
-    name: "linux; Dart dev; PKG: test_pkg; `pub run test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart dev; PKG: test_pkg; `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.3.0
+# Created with package:mono_repo v3.3.1-dev
 name: Dart CI
 on:
   push:
@@ -16,7 +16,7 @@ env:
 
 jobs:
   job_001:
-    name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
+    name: "linux; Dart dev; PKG: mono_repo; `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -39,7 +39,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh command
   job_002:
-    name: "OS: linux; SDK: dev; PKGS: mono_repo, test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`]"
+    name: "linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -62,7 +62,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartfmt dartanalyzer_0
   job_003:
-    name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `dartanalyzer .`"
+    name: "linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -86,7 +86,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_1
   job_004:
-    name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -114,7 +114,7 @@ jobs:
       - job_002
       - job_003
   job_005:
-    name: "OS: windows; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "windows; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -132,7 +132,7 @@ jobs:
       - job_002
       - job_003
   job_006:
-    name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "linux; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -159,7 +159,7 @@ jobs:
       - job_002
       - job_003
   job_007:
-    name: "OS: windows; SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "windows; Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -176,7 +176,7 @@ jobs:
       - job_002
       - job_003
   job_008:
-    name: "OS: linux; SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
+    name: "linux; Dart 2.7.0; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -204,7 +204,7 @@ jobs:
       - job_002
       - job_003
   job_009:
-    name: "OS: linux; SDK: dev; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
+    name: "linux; Dart dev; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -231,7 +231,7 @@ jobs:
       - job_002
       - job_003
   job_010:
-    name: "OS: linux; SDK: dev; PKG: test_pkg; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    name: "linux; Dart dev; PKG: test_pkg; `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,64 @@
-# Created with package:mono_repo v3.3.0
+# Created with package:mono_repo v3.3.1-dev
 language: dart
 
 jobs:
   include:
     - stage: smoke_test
-      name: "SDK: dev; PKGS: mono_repo, test_pkg; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`]"
+      name: "Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
       dart: dev
       os: linux
       env: PKGS="mono_repo test_pkg"
       script: tool/ci.sh dartfmt dartanalyzer_0
     - stage: smoke_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
+      name: "Dart dev; PKG: mono_repo; `cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh command
     - stage: smoke_test
-      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `dartanalyzer .`"
+      name: "Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
       dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh dartanalyzer_1
     - stage: unit_test
-      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+      name: "Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
       dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+      name: "Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
       dart: "2.7.0"
       os: windows
       env: PKGS="mono_repo"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+      name: "Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+      name: "Dart dev; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="mono_repo"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: 2.7.0; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
+      name: "Dart 2.7.0; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
       dart: "2.7.0"
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: dev; PKG: mono_repo; TASKS: `pub run test -t yaml --test-randomize-ordering-seed=random`"
+      name: "Dart dev; PKG: mono_repo; `pub run test -t yaml --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="mono_repo"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: dev; PKG: test_pkg; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      name: "Dart dev; PKG: test_pkg; `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="test_pkg"

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.3.1-dev
+
+- Cleanup the names generated for each job.
+
+### GitHub Actions
+
+- Shorten the generated names for a job if a given component of the name is
+  identical for all tasks. Makes it easier to read the names in the GitHub
+  Action UI.
+
 ## 3.3.0
 
 - Implemented proper support for `stages` in github actions. Jobs will now

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -50,9 +50,11 @@ class CIJobEntry {
     @required bool includeOs,
     @required bool includeSdk,
     @required bool includePackage,
+    @required bool includeStage,
   }) {
     final packageLabel = packages.length == 1 ? 'PKG' : 'PKGS';
     final sections = [
+      if (includeStage && job.stageName != null) job.stageName,
       if (!includeOs) job.os,
       if (!includeSdk) 'Dart ${job.sdk}',
       if (!includePackage) '$packageLabel: ${packages.join(', ')}',

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -45,11 +45,21 @@ class CIJobEntry {
 
   CIJobEntry(this.job, this.commands);
 
-  String jobName(List<String> packages) {
-    final pkgLabel = packages.length == 1 ? 'PKG' : 'PKGS';
+  String jobName(
+    List<String> packages, {
+    @required bool oneOs,
+    @required bool oneSdk,
+    @required bool onePackage,
+  }) {
+    final packageLabel = packages.length == 1 ? 'PKG' : 'PKGS';
+    final sections = [
+      if (!oneOs) job.os,
+      if (!oneSdk) 'Dart ${job.sdk}',
+      if (!onePackage) '$packageLabel: ${packages.join(', ')}',
+      job.name,
+    ];
 
-    return 'SDK: ${job.sdk}; $pkgLabel: ${packages.join(', ')}; '
-        'TASKS: ${job.name}';
+    return sections.join('; ');
   }
 }
 

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -47,15 +47,15 @@ class CIJobEntry {
 
   String jobName(
     List<String> packages, {
-    @required bool oneOs,
-    @required bool oneSdk,
-    @required bool onePackage,
+    @required bool includeOs,
+    @required bool includeSdk,
+    @required bool includePackage,
   }) {
     final packageLabel = packages.length == 1 ? 'PKG' : 'PKGS';
     final sections = [
-      if (!oneOs) job.os,
-      if (!oneSdk) 'Dart ${job.sdk}',
-      if (!onePackage) '$packageLabel: ${packages.join(', ')}',
+      if (!includeOs) job.os,
+      if (!includeSdk) 'Dart ${job.sdk}',
+      if (!includePackage) '$packageLabel: ${packages.join(', ')}',
       job.name,
     ];
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -247,6 +247,7 @@ extension on CIJobEntry {
         includeOs: oneOs,
         includeSdk: oneSdk,
         includePackage: onePackage,
+        includeStage: true,
       ),
       _githubJobOs,
       job.sdk,

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -242,7 +242,7 @@ extension on CIJobEntry {
     assert(packages.contains(job.package));
 
     return _githubJobYaml(
-      jobName(packages, oneOs: oneOs, oneSdk: oneSdk, onePackage: onePackage),
+      jobName(packages, includeOs: oneOs, includeSdk: oneSdk, includePackage: onePackage),
       _githubJobOs,
       job.sdk,
       [

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:io/ansi.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../../ci_shared.dart';
@@ -123,7 +124,7 @@ ${toYaml({'jobs': jobList})}
 }
 
 /// Lists all the jobs, setting their stage, environment, and script.
-Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
+Iterable<_MapEntryWithStage> _listJobs(
   Iterable<HasStageName> jobs,
   Map<String, String> commandsToKeys,
   Set<String> mergeStages,
@@ -136,7 +137,7 @@ Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
 
   String jobName(int jobNum) => 'job_${jobNum.toString().padLeft(3, '0')}';
 
-  _MapEntryWithStage<String, Map<String, dynamic>> jobEntry(
+  _MapEntryWithStage jobEntry(
     Map<String, dynamic> content,
     String stage,
   ) {
@@ -161,6 +162,16 @@ Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
     jobEntries.add(CIJobEntry(ciJob, commands));
   }
 
+  final differentOperatingSystems = <String>{};
+  final differentPackages = <String>{};
+  final differentSdks = <String>{};
+
+  for (var entry in jobEntries) {
+    differentOperatingSystems.add(entry.job.os);
+    differentPackages.add(entry.job.package);
+    differentSdks.add(entry.job.sdk);
+  }
+
   // Group jobs by all of the values that would allow them to merge
   final groupedItems = groupCIJobEntries(jobEntries);
 
@@ -174,9 +185,24 @@ Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
 
     if (mergeStages.contains(first.job.stageName)) {
       final packages = entry.value.map((t) => t.job.package).toList();
-      yield jobEntry(first.jobYaml(packages), first.job.stageName);
+      yield jobEntry(
+          first.jobYaml(
+            packages: packages,
+            oneOs: differentOperatingSystems.length == 1,
+            oneSdk: differentSdks.length == 1,
+            onePackage: differentPackages.length == 1,
+          ),
+          first.job.stageName);
     } else {
-      yield* entry.value.map((e) => jobEntry(e.jobYaml(), e.job.stageName));
+      yield* entry.value.map(
+        (e) => jobEntry(
+            e.jobYaml(
+              oneOs: differentOperatingSystems.length == 1,
+              oneSdk: differentSdks.length == 1,
+              onePackage: differentPackages.length == 1,
+            ),
+            e.job.stageName),
+      );
     }
   }
 
@@ -192,13 +218,6 @@ Iterable<_MapEntryWithStage<String, Map<String, dynamic>>> _listJobs(
 }
 
 extension on CIJobEntry {
-  String _jobName(List<String> packages) {
-    final pkgLabel = packages.length == 1 ? 'PKG' : 'PKGS';
-
-    return 'OS: ${job.os}; SDK: ${job.sdk}; $pkgLabel: ${packages.join(', ')}; '
-        'TASKS: ${job.name}';
-  }
-
   String get _githubJobOs {
     switch (job.os) {
       case 'linux':
@@ -212,13 +231,18 @@ extension on CIJobEntry {
     throw UnsupportedError('Not sure how to map `${job.os}` to GitHub!');
   }
 
-  Map<String, dynamic> jobYaml([List<String> packages]) {
+  Map<String, dynamic> jobYaml({
+    List<String> packages,
+    @required bool oneOs,
+    @required bool oneSdk,
+    @required bool onePackage,
+  }) {
     packages ??= [job.package];
     assert(packages.isNotEmpty);
     assert(packages.contains(job.package));
 
     return _githubJobYaml(
-      _jobName(packages),
+      jobName(packages, oneOs: oneOs, oneSdk: oneSdk, onePackage: onePackage),
       _githubJobOs,
       job.sdk,
       [
@@ -395,11 +419,11 @@ class _SelfValidateJob implements HasStageName {
   _SelfValidateJob(this.stageName);
 }
 
-class _MapEntryWithStage<K, V> implements MapEntry<K, V> {
+class _MapEntryWithStage implements MapEntry<String, Map<String, dynamic>> {
   @override
-  final K key;
+  final String key;
   @override
-  final V value;
+  final Map<String, dynamic> value;
 
   final String stageName;
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -242,7 +242,12 @@ extension on CIJobEntry {
     assert(packages.contains(job.package));
 
     return _githubJobYaml(
-      jobName(packages, includeOs: oneOs, includeSdk: oneSdk, includePackage: onePackage),
+      jobName(
+        packages,
+        includeOs: oneOs,
+        includeSdk: oneSdk,
+        includePackage: onePackage,
+      ),
       _githubJobOs,
       job.sdk,
       [

--- a/mono_repo/lib/src/commands/travis/travis_yaml.dart
+++ b/mono_repo/lib/src/commands/travis/travis_yaml.dart
@@ -166,6 +166,7 @@ extension on CIJobEntry {
         includeOs: true,
         includeSdk: oneSdk,
         includePackage: onePackage,
+        includeStage: false,
       ),
       'dart': job.sdk,
       'os': job.os,

--- a/mono_repo/lib/src/commands/travis/travis_yaml.dart
+++ b/mono_repo/lib/src/commands/travis/travis_yaml.dart
@@ -163,9 +163,9 @@ extension on CIJobEntry {
       'stage': job.stageName,
       'name': jobName(
         packages,
-        oneOs: true,
-        oneSdk: oneSdk,
-        onePackage: onePackage,
+        includeOs: true,
+        includeSdk: oneSdk,
+        includePackage: onePackage,
       ),
       'dart': job.sdk,
       'os': job.os,

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -183,12 +183,8 @@ class CIJob implements HasStageName {
   Iterable<String> get _taskCommandsTickQuoted =>
       tasks.map((t) => '`${t.command}`');
 
-  /// The description of the job to use for the job in the travis dashboard.
-  String get name =>
-      description ??
-      (tasks.length > 1
-          ? _taskCommandsTickQuoted.toList().toString()
-          : _taskCommandsTickQuoted.first);
+  /// The description of the job in the CI environment.
+  String get name => description ?? _taskCommandsTickQuoted.join(', ');
 
   CIJob(
     this.os,

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.3.0';
+const packageVersion = '3.3.1-dev';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 3.3.0
+version: 3.3.1-dev
 repository: https://github.com/google/mono_repo.dart
 
 environment:

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -336,19 +336,19 @@ language: dart
 jobs:
   include:
     - stage: format
-      name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "Dart dev; PKG: pkg_a; `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh dartfmt
     - stage: format
-      name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "Dart stable; PKG: pkg_a; `dartfmt -n --set-exit-if-changed .`"
       dart: stable
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh dartfmt
     - stage: format
-      name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "Dart dev; PKG: pkg_b; `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: linux
       env: PKGS="pkg_b"
@@ -439,19 +439,19 @@ language: dart
 jobs:
   include:
     - stage: format
-      name: "SDK: dev; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "Dart dev; PKG: pkg_a; `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh dartfmt_0
     - stage: format
-      name: "SDK: stable; PKG: pkg_a; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "Dart stable; PKG: pkg_a; `dartfmt -n --set-exit-if-changed .`"
       dart: stable
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh dartfmt_0
     - stage: format
-      name: "SDK: dev; PKG: pkg_b; TASKS: `dartfmt --dry-run --fix --set-exit-if-changed .`"
+      name: "Dart dev; PKG: pkg_b; `dartfmt --dry-run --fix --set-exit-if-changed .`"
       dart: dev
       os: linux
       env: PKGS="pkg_b"
@@ -567,25 +567,25 @@ language: dart
 jobs:
   include:
     - stage: analyze
-      name: "SDK: 1.23.0; PKG: pkg_a; TASKS: `dartanalyzer .`"
+      name: "Dart 1.23.0; `dartanalyzer .`"
       dart: "1.23.0"
       os: windows
       env: PKGS="pkg_a"
       script: tool/ci.sh dartanalyzer
     - stage: analyze
-      name: "SDK: dev; PKG: pkg_a; TASKS: [`dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`]"
+      name: "Dart dev; `dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: osx
       env: PKGS="pkg_a"
       script: tool/ci.sh dartanalyzer dartfmt
     - stage: unit_test
-      name: "SDK: dev; PKG: pkg_a; TASKS: chrome tests"
+      name: Dart dev; chrome tests
       dart: dev
       os: macos
       env: PKGS="pkg_a"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: stable; PKG: pkg_a; TASKS: `pub run test --preset travis`"
+      name: "Dart stable; `pub run test --preset travis`"
       dart: stable
       os: linux
       env: PKGS="pkg_a"
@@ -877,31 +877,31 @@ language: dart
 jobs:
   include:
     - stage: analyze
-      name: "SDK: stable; PKGS: pkg_a, pkg_b; TASKS: [`dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`]"
+      name: "PKGS: pkg_a, pkg_b; `dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`"
       dart: stable
       os: linux
       env: PKGS="pkg_a pkg_b"
       script: tool/ci.sh dartanalyzer dartfmt
     - stage: unit_test
-      name: "SDK: stable; PKG: pkg_a; TASKS: chrome tests"
+      name: "PKG: pkg_a; chrome tests"
       dart: stable
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: stable; PKG: pkg_a; TASKS: `pub run test --preset travis`"
+      name: "PKG: pkg_a; `pub run test --preset travis`"
       dart: stable
       os: linux
       env: PKGS="pkg_a"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: stable; PKG: pkg_b; TASKS: chrome tests"
+      name: "PKG: pkg_b; chrome tests"
       dart: stable
       os: linux
       env: PKGS="pkg_b"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: stable; PKG: pkg_b; TASKS: `pub run test --preset travis`"
+      name: "PKG: pkg_b; `pub run test --preset travis`"
       dart: stable
       os: linux
       env: PKGS="pkg_b"

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -17,7 +17,7 @@ env:
 
 jobs:
   job_001:
-    name: "linux; `pub run test`"
+    name: "unit_test; linux; `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -40,7 +40,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test
   job_002:
-    name: "linux; `pub run test`"
+    name: "cron; linux; `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -66,7 +66,7 @@ jobs:
     needs:
       - job_001
   job_003:
-    name: "windows; `pub run test`"
+    name: "cron; windows; `pub run test`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -17,7 +17,7 @@ env:
 
 jobs:
   job_001:
-    name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+    name: "linux; `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -40,7 +40,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test
   job_002:
-    name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+    name: "linux; `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -66,7 +66,7 @@ jobs:
     needs:
       - job_001
   job_003:
-    name: "OS: windows; SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+    name: "windows; `pub run test`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -37,7 +37,7 @@ jobs:
       - run: pub global activate mono_repo 1.2.3
       - run: pub global run mono_repo generate --validate
   job_002:
-    name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `dartanalyzer .`"
+    name: "`dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -60,7 +60,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer
   job_003:
-    name: "OS: linux; SDK: dev; PKG: sub_pkg; TASKS: `dartfmt -n --set-exit-if-changed .`"
+    name: "`dartfmt -n --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -37,7 +37,7 @@ jobs:
       - run: pub global activate mono_repo 1.2.3
       - run: pub global run mono_repo generate --validate
   job_002:
-    name: "`dartanalyzer .`"
+    name: "analyze; `dartanalyzer .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -60,7 +60,7 @@ jobs:
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer
   job_003:
-    name: "`dartfmt -n --set-exit-if-changed .`"
+    name: "analyze; `dartfmt -n --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies

--- a/mono_repo/test/script_integration_outputs/readme_travis.txt
+++ b/mono_repo/test/script_integration_outputs/readme_travis.txt
@@ -12,31 +12,31 @@ jobs:
       os: linux
       script: "pub global activate mono_repo 1.2.3 && pub global run mono_repo generate --validate"
     - stage: analyze
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `dartanalyzer .`"
+      name: "`dartanalyzer .`"
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh dartanalyzer
     - stage: analyze
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "`dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh dartfmt
     - stage: unit_test
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      name: "`pub run test`"
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test
     - stage: cron
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      name: "`pub run test`"
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test
     - stage: cron
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test`"
+      name: "`pub run test`"
       dart: dev
       os: windows
       env: PKGS="sub_pkg"

--- a/mono_repo/test/src/expected_output.dart
+++ b/mono_repo/test/src/expected_output.dart
@@ -98,85 +98,85 @@ language: dart
 jobs:
   include:
     - stage: analyze
-      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `dartanalyzer .`"
+      name: "Dart 1.23.0; `dartanalyzer .`"
       dart: "1.23.0"
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh dartanalyzer
     - stage: analyze
-      name: "SDK: dev; PKG: sub_pkg; TASKS: [`dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`]"
+      name: "Dart dev; `dartanalyzer .`, `dartfmt -n --set-exit-if-changed .`"
       dart: dev
       os: osx
       env: PKGS="sub_pkg"
       script: tool/ci.sh dartanalyzer dartfmt
     - stage: unit_test
-      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart 1.23.0; chrome tests
       dart: "1.23.0"
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart 1.23.0; chrome tests
       dart: "1.23.0"
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: dev; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart dev; chrome tests
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: dev; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart dev; chrome tests
       dart: dev
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: stable; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart stable; chrome tests
       dart: stable
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: stable; PKG: sub_pkg; TASKS: chrome tests"
+      name: Dart stable; chrome tests
       dart: stable
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_0
     - stage: unit_test
-      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart 1.23.0; `pub run test --preset travis`"
       dart: "1.23.0"
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: 1.23.0; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart 1.23.0; `pub run test --preset travis`"
       dart: "1.23.0"
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart dev; `pub run test --preset travis`"
       dart: dev
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: dev; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart dev; `pub run test --preset travis`"
       dart: dev
       os: windows
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart stable; `pub run test --preset travis`"
       dart: stable
       os: linux
       env: PKGS="sub_pkg"
       script: tool/ci.sh test_1
     - stage: unit_test
-      name: "SDK: stable; PKG: sub_pkg; TASKS: `pub run test --preset travis`"
+      name: "Dart stable; `pub run test --preset travis`"
       dart: stable
       os: windows
       env: PKGS="sub_pkg"

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.3.0
+# Created with package:mono_repo v3.3.1-dev
 
 # Support built in commands on windows out of the box.
 function pub() {


### PR DESCRIPTION
Remove superfluous `[]` when there is more than one task
If there is one task, change the header to TASK instead of TASKS
GitHub: only generate a name section if it is distinct from other jobs
