### PR TITLE
Github actions: separate out jobs into multiple steps with nice names

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
@@ -71,13 +71,13 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
@@ -87,13 +87,13 @@ jobs:
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
-        if: steps.test_pkg_pub_upgrade.conclusion == success()
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
-        if: steps.test_pkg_pub_upgrade.conclusion == success()
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
@@ -123,7 +123,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
   job_004:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
@@ -153,7 +153,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -177,7 +177,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -210,7 +210,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -233,7 +233,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -267,7 +267,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -300,7 +300,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: steps.mono_repo_pub_upgrade.conclusion == success()
+        if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001
@@ -333,7 +333,7 @@ jobs:
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
-        if: steps.test_pkg_pub_upgrade.conclusion == success()
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
         continue-on-error: true
     needs:
       - job_001

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,11 +37,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -64,29 +66,35 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: steps.test_pkg_pub_upgrade.conclusion == success()
+        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: steps.test_pkg_pub_upgrade.conclusion == success()
+        continue-on-error: true
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -110,11 +118,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
   job_004:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -138,11 +148,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -160,11 +172,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         run: "cd mono_repo && pub.bat upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -191,11 +205,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -212,11 +228,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         run: "cd mono_repo && pub.bat upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -244,11 +262,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -275,11 +295,13 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
         if: steps.mono_repo_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -306,11 +328,13 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
       - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
         if: steps.test_pkg_pub_upgrade.conclusion == success()
+        continue-on-error: true
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -35,8 +35,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
@@ -62,8 +62,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
@@ -75,8 +75,8 @@ jobs:
         run: tool/ci.sh dartanalyzer_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
       - id: test_pkg_pub_upgrade
-        name: "test_pkg; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "test_pkg; cd pub upgrade --no-precompile"
+        run: "cd test_pkg && cd pub upgrade --no-precompile"
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
@@ -108,8 +108,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
@@ -136,8 +136,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -158,8 +158,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub.bat upgrade --no-precompile"
-        run: pub.bat upgrade --no-precompile
+        name: "mono_repo; cd pub.bat upgrade --no-precompile"
+        run: "cd mono_repo && cd pub.bat upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -189,8 +189,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -210,8 +210,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub.bat upgrade --no-precompile"
-        run: pub.bat upgrade --no-precompile
+        name: "mono_repo; cd pub.bat upgrade --no-precompile"
+        run: "cd mono_repo && cd pub.bat upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -242,8 +242,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -273,8 +273,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "mono_repo; cd pub upgrade --no-precompile"
+        run: "cd mono_repo && cd pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -304,8 +304,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: test_pkg_pub_upgrade
-        name: "test_pkg; pub upgrade --no-precompile"
-        run: pub upgrade --no-precompile
+        name: "test_pkg; cd pub upgrade --no-precompile"
+        run: "cd test_pkg && cd pub upgrade --no-precompile"
       - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,13 +37,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -66,35 +64,29 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -118,13 +110,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_004:
     name: "smoke_test; linux; Dart beta; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -147,19 +137,16 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_005:
     name: "smoke_test; linux; Dart stable; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -182,19 +169,16 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_006:
     name: "smoke_test; linux; Dart 2.12.0-0.0.dev; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -218,19 +202,16 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_007:
     name: "smoke_test; linux; Dart 2.12.0-29.10.beta; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -254,19 +235,16 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
   job_008:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -290,13 +268,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -318,13 +294,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         run: "cd mono_repo && pub.bat upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -355,13 +329,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -382,13 +354,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         run: "cd mono_repo && pub.bat upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -420,13 +390,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -457,13 +425,11 @@ jobs:
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         run: "cd mono_repo && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
         if: "steps.mono_repo_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002
@@ -494,13 +460,11 @@ jobs:
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: "cd test_pkg && pub upgrade --no-precompile"
-        continue-on-error: true
       - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
         if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
-        continue-on-error: true
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
+        if: always()
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -61,18 +62,22 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
+        if: always()
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
+        if: always()
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
+        if: always()
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
+        if: always()
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -97,6 +102,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
+        if: always()
   job_004:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -121,6 +127,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
+        if: always()
     needs:
       - job_001
       - job_002
@@ -139,6 +146,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
+        if: always()
     needs:
       - job_001
       - job_002
@@ -166,6 +174,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
+        if: always()
     needs:
       - job_001
       - job_002
@@ -183,6 +192,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
+        if: always()
     needs:
       - job_001
       - job_002
@@ -211,6 +221,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
+        if: always()
     needs:
       - job_001
       - job_002
@@ -238,6 +249,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
+        if: always()
     needs:
       - job_001
       - job_002
@@ -265,6 +277,7 @@ jobs:
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
+        if: always()
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -144,9 +144,22 @@ jobs:
           release-channel: beta
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
+      - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
+        env:
           PKGS: test_pkg
-        run: tool/ci.sh dartfmt dartanalyzer_0
+        run: tool/ci.sh dartfmt
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
+      - name: "test_pkg; dartanalyzer --fatal-infos ."
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartanalyzer_0
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
   job_005:
     name: "smoke_test; linux; Dart stable; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -166,9 +179,22 @@ jobs:
           release-channel: stable
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
+      - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
+        env:
           PKGS: test_pkg
-        run: tool/ci.sh dartfmt dartanalyzer_0
+        run: tool/ci.sh dartfmt
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
+      - name: "test_pkg; dartanalyzer --fatal-infos ."
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartanalyzer_0
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
   job_006:
     name: "smoke_test; linux; Dart 2.12.0-0.0.dev; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -189,9 +215,22 @@ jobs:
           version: "2.12.0-0.0.dev"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
+      - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
+        env:
           PKGS: test_pkg
-        run: tool/ci.sh dartfmt dartanalyzer_0
+        run: tool/ci.sh dartfmt
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
+      - name: "test_pkg; dartanalyzer --fatal-infos ."
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartanalyzer_0
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
   job_007:
     name: "smoke_test; linux; Dart 2.12.0-29.10.beta; PKG: test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -212,9 +251,22 @@ jobs:
           version: "2.12.0-29.10.beta"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
+        continue-on-error: true
+      - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
+        env:
           PKGS: test_pkg
-        run: tool/ci.sh dartfmt dartanalyzer_0
+        run: tool/ci.sh dartfmt
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
+      - name: "test_pkg; dartanalyzer --fatal-infos ."
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartanalyzer_0
+        if: "steps.test_pkg_pub_upgrade.conclusion == 'success'"
+        continue-on-error: true
   job_008:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -34,11 +34,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -58,26 +61,32 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
-        if: always()
+        if: steps.test_pkg_pub_upgrade.conclusion == "success"
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
-        if: always()
+        if: steps.test_pkg_pub_upgrade.conclusion == "success"
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -98,11 +107,14 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
   job_004:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -123,11 +135,14 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -142,11 +157,14 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub.bat upgrade --no-precompile"
+        run: pub.bat upgrade --no-precompile
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -170,11 +188,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -188,11 +209,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub.bat upgrade --no-precompile"
+        run: pub.bat upgrade --no-precompile
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -217,11 +241,14 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -245,11 +272,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: mono_repo_pub_upgrade
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: always()
+        if: steps.mono_repo_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002
@@ -273,11 +303,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
+      - id: test_pkg_pub_upgrade
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: pub upgrade --no-precompile
       - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
-        if: always()
+        if: steps.test_pkg_pub_upgrade.conclusion == "success"
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -34,7 +34,8 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh command
   job_002:
@@ -56,9 +57,22 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
-          PKGS: mono_repo test_pkg
-        run: tool/ci.sh dartfmt dartanalyzer_0
+      - name: dartfmt -n --set-exit-if-changed .
+        env:
+          PKGS: mono_repo
+        run: tool/ci.sh dartfmt
+      - name: dartanalyzer --fatal-infos .
+        env:
+          PKGS: mono_repo
+        run: tool/ci.sh dartanalyzer_0
+      - name: dartfmt -n --set-exit-if-changed .
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartfmt
+      - name: dartanalyzer --fatal-infos .
+        env:
+          PKGS: test_pkg
+        run: tool/ci.sh dartanalyzer_0
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -79,7 +93,8 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: dartanalyzer .
+        env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
   job_004:
@@ -102,7 +117,8 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
     needs:
@@ -119,7 +135,8 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
     needs:
@@ -145,7 +162,8 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
     needs:
@@ -161,7 +179,8 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
     needs:
@@ -188,7 +207,8 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -t yaml --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
     needs:
@@ -214,7 +234,8 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test -t yaml --test-randomize-ordering-seed=random"
+        env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
     needs:
@@ -240,7 +261,8 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - name: "pub run test --test-randomize-ordering-seed=random"
+        env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
     needs:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -35,8 +35,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
@@ -62,8 +62,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
@@ -75,8 +75,8 @@ jobs:
         run: tool/ci.sh dartanalyzer_0
         if: steps.mono_repo_pub_upgrade.conclusion == success()
       - id: test_pkg_pub_upgrade
-        name: "test_pkg; cd pub upgrade --no-precompile"
-        run: "cd test_pkg && cd pub upgrade --no-precompile"
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
       - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
@@ -108,8 +108,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
@@ -136,8 +136,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -158,8 +158,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub.bat upgrade --no-precompile"
-        run: "cd mono_repo && cd pub.bat upgrade --no-precompile"
+        name: "mono_repo; pub.bat upgrade --no-precompile"
+        run: "cd mono_repo && pub.bat upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -189,8 +189,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -210,8 +210,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub.bat upgrade --no-precompile"
-        run: "cd mono_repo && cd pub.bat upgrade --no-precompile"
+        name: "mono_repo; pub.bat upgrade --no-precompile"
+        run: "cd mono_repo && pub.bat upgrade --no-precompile"
       - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -242,8 +242,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -273,8 +273,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: mono_repo_pub_upgrade
-        name: "mono_repo; cd pub upgrade --no-precompile"
-        run: "cd mono_repo && cd pub upgrade --no-precompile"
+        name: "mono_repo; pub upgrade --no-precompile"
+        run: "cd mono_repo && pub upgrade --no-precompile"
       - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
@@ -304,8 +304,8 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - id: test_pkg_pub_upgrade
-        name: "test_pkg; cd pub upgrade --no-precompile"
-        run: "cd test_pkg && cd pub upgrade --no-precompile"
+        name: "test_pkg; pub upgrade --no-precompile"
+        run: "cd test_pkg && pub upgrade --no-precompile"
       - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -34,7 +34,7 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
+      - name: "mono_repo; cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate"
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
@@ -57,19 +57,19 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: dartfmt -n --set-exit-if-changed .
+      - name: "mono_repo; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
-      - name: dartanalyzer --fatal-infos .
+      - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
-      - name: dartfmt -n --set-exit-if-changed .
+      - name: "test_pkg; dartfmt -n --set-exit-if-changed ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
-      - name: dartanalyzer --fatal-infos .
+      - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
@@ -93,7 +93,7 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: dartanalyzer .
+      - name: mono_repo; dartanalyzer .
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
@@ -117,7 +117,7 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
@@ -135,7 +135,7 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
@@ -162,7 +162,7 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
@@ -179,7 +179,7 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
@@ -207,7 +207,7 @@ jobs:
           version: "2.7.0"
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -t yaml --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
@@ -234,7 +234,7 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test -t yaml --test-randomize-ordering-seed=random"
+      - name: "mono_repo; pub run test -t yaml --test-randomize-ordering-seed=random"
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
@@ -261,7 +261,7 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - name: "pub run test --test-randomize-ordering-seed=random"
+      - name: "test_pkg; pub run test --test-randomize-ordering-seed=random"
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh command
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
   job_002:
     name: "smoke_test; linux; Dart dev; PKGS: mono_repo, test_pkg; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -68,12 +68,12 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartfmt
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
       - name: "mono_repo; dartanalyzer --fatal-infos ."
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_0
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         run: pub upgrade --no-precompile
@@ -81,12 +81,12 @@ jobs:
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartfmt
-        if: steps.test_pkg_pub_upgrade.conclusion == "success"
+        if: steps.test_pkg_pub_upgrade.conclusion == success()
       - name: "test_pkg; dartanalyzer --fatal-infos ."
         env:
           PKGS: test_pkg
         run: tool/ci.sh dartanalyzer_0
-        if: steps.test_pkg_pub_upgrade.conclusion == "success"
+        if: steps.test_pkg_pub_upgrade.conclusion == success()
   job_003:
     name: "smoke_test; linux; Dart 2.7.0; PKG: mono_repo; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -114,7 +114,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh dartanalyzer_1
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
   job_004:
     name: "unit_test; linux; Dart 2.7.0; PKG: mono_repo; `pub run test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -142,7 +142,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -164,7 +164,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -195,7 +195,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -216,7 +216,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_0
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -248,7 +248,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -279,7 +279,7 @@ jobs:
         env:
           PKGS: mono_repo
         run: tool/ci.sh test_1
-        if: steps.mono_repo_pub_upgrade.conclusion == "success"
+        if: steps.mono_repo_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002
@@ -310,7 +310,7 @@ jobs:
         env:
           PKGS: test_pkg
         run: tool/ci.sh test_2
-        if: steps.test_pkg_pub_upgrade.conclusion == "success"
+        if: steps.test_pkg_pub_upgrade.conclusion == success()
     needs:
       - job_001
       - job_002

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Detect running on Windows on GitHub without setting an extra environment
   variable.
+- Separate job commands into a step for each. This makes it easier to see
+  exactly what commands were ran on what packages, as well as their individual
+  status and output.
 
 ## 3.3.0
 

--- a/mono_repo/lib/src/ci_test_script.dart
+++ b/mono_repo/lib/src/ci_test_script.dart
@@ -56,7 +56,10 @@ for PKG in \${PKGS}; do
     exit 64
   fi
 
-  pub $pubDependencyCommand --no-precompile || EXIT_CODE=\$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z \${GITHUB_ACTIONS} ]]; then
+    pub $pubDependencyCommand --no-precompile || EXIT_CODE=\$?
+  fi
 
   if [[ \${EXIT_CODE} -ne 0 ]]; then
     ${echoWithEvaluation(prettyAnsi, red, "PKG: \${PKG}; 'pub $pubDependencyCommand' - FAILED  (\${EXIT_CODE})")}

--- a/mono_repo/lib/src/ci_test_script.dart
+++ b/mono_repo/lib/src/ci_test_script.dart
@@ -57,7 +57,7 @@ for PKG in \${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z \${GITHUB_ACTIONS} ]]; then
+  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
     pub $pubDependencyCommand --no-precompile || EXIT_CODE=\$?
   fi
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -258,7 +258,7 @@ extension on CIJobEntry {
         for (var package in packages)
           for (var i = 0; i < commands.length; i++)
             _CommandEntry(
-              job.tasks[i].command,
+              '$package; ${job.tasks[i].command}',
               '$ciScriptPath ${commands[i]}',
               env: {
                 'PKGS': package,

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -266,6 +266,8 @@ extension on CIJobEntry {
           env: {
             'PKGS': package,
           },
+          // Run this regardless of the success of other steps other than the
+          // pub step.
           ifCondition: 'steps.$pubStepId.conclusion == success()',
         ));
       }
@@ -395,9 +397,9 @@ class _CommandEntry {
         'name': name,
         if (env != null && env.isNotEmpty) 'env': env,
         'run': run,
-        // We want to run even if other steps failed, use stages if you want
-        // to block things on previous failures.
         if (ifCondition != null) 'if': ifCondition,
+        // Required to access the conclusion condition of previous steps
+        'continue-on-error': true,
       };
 }
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -266,7 +266,7 @@ extension on CIJobEntry {
           env: {
             'PKGS': package,
           },
-          ifCondition: 'steps.$pubStepId.conclusion == "success"',
+          ifCondition: 'steps.$pubStepId.conclusion == success()',
         ));
       }
     }

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -268,7 +268,7 @@ extension on CIJobEntry {
           },
           // Run this regardless of the success of other steps other than the
           // pub step.
-          ifCondition: 'steps.$pubStepId.conclusion == success()',
+          ifCondition: "steps.$pubStepId.conclusion == 'success'",
         ));
       }
     }

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -248,7 +248,7 @@ extension on CIJobEntry {
     packages ??= [job.package];
     assert(packages.isNotEmpty);
     assert(packages.contains(job.package));
-    final pubCommand = 'pub${job.os == 'windows' ? '.bat' : ''} '
+    final pubCommand = 'cd pub${job.os == 'windows' ? '.bat' : ''} '
         '${rootConfig.monoConfig.pubAction} --no-precompile';
 
     final commandEntries = <_CommandEntry>[];
@@ -256,7 +256,7 @@ extension on CIJobEntry {
       final pubStepId = '${package}_pub_${rootConfig.monoConfig.pubAction}';
       commandEntries.add(_CommandEntry(
         '$package; $pubCommand',
-        pubCommand,
+        'cd $package && $pubCommand',
         id: pubStepId,
       ));
       for (var i = 0; i < commands.length; i++) {

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -408,8 +408,6 @@ class _CommandEntry {
         if (env != null && env.isNotEmpty) 'env': env,
         'run': run,
         if (ifCondition != null) 'if': ifCondition,
-        // Required to access the conclusion condition of previous steps
-        'continue-on-error': true,
       };
 }
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -255,12 +255,15 @@ extension on CIJobEntry {
       _githubJobOs,
       job.sdk,
       [
-        _CommandEntry(
-          '$ciScriptPath ${commands.join(' ')}',
-          env: {
-            'PKGS': packages.join(' '),
-          },
-        )
+        for (var package in packages)
+          for (var i = 0; i < commands.length; i++)
+            _CommandEntry(
+              job.tasks[i].command,
+              '$ciScriptPath ${commands[i]}',
+              env: {
+                'PKGS': package,
+              },
+            )
       ],
       additionalCacheKeys: {
         'packages': packages.join('-'),
@@ -353,10 +356,12 @@ Map<String, dynamic> _githubJobYaml(
     };
 
 class _CommandEntry {
+  final String name;
   final String run;
   final Map<String, String> env;
 
   _CommandEntry(
+    this.name,
     this.run, {
     this.env,
   });
@@ -365,6 +370,7 @@ class _CommandEntry {
   ///
   /// See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
   Map<String, dynamic> get runContent => {
+        'name': name,
         if (env != null && env.isNotEmpty) 'env': env,
         'run': run,
       };
@@ -414,7 +420,8 @@ Map<String, dynamic> _selfValidateTaskConfig() => _githubJobYaml(
       'ubuntu-latest',
       'stable',
       [
-        for (var command in selfValidateCommands) _CommandEntry(command),
+        for (var command in selfValidateCommands)
+          _CommandEntry(selfValidateJobName, command),
       ],
     );
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -373,6 +373,9 @@ class _CommandEntry {
         'name': name,
         if (env != null && env.isNotEmpty) 'env': env,
         'run': run,
+        // We want to run even if other steps failed, use stages if you want
+        // to block things on previous failures.
+        'if': 'always()',
       };
 }
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -248,7 +248,7 @@ extension on CIJobEntry {
     packages ??= [job.package];
     assert(packages.isNotEmpty);
     assert(packages.contains(job.package));
-    final pubCommand = 'cd pub${job.os == 'windows' ? '.bat' : ''} '
+    final pubCommand = 'pub${job.os == 'windows' ? '.bat' : ''} '
         '${rootConfig.monoConfig.pubAction} --no-precompile';
 
     final commandEntries = <_CommandEntry>[];

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -974,7 +974,7 @@ line 1, column 13 of mono_repo.yaml: Unsupported value for "pub_action". Value m
         await d.file(travisFileName, travisYamlOutput).validate();
         await d.file(ciScriptPath, contains(r'''
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z ${GITHUB_ACTIONS} ]]; then
+  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
     pub get --no-precompile || EXIT_CODE=$?
   fi
 
@@ -1038,7 +1038,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z ${GITHUB_ACTIONS} ]]; then
+  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -973,7 +973,10 @@ line 1, column 13 of mono_repo.yaml: Unsupported value for "pub_action". Value m
         // TODO: validate GitHub case
         await d.file(travisFileName, travisYamlOutput).validate();
         await d.file(ciScriptPath, contains(r'''
-  pub get --no-precompile || EXIT_CODE=$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z ${GITHUB_ACTIONS} ]]; then
+    pub get --no-precompile || EXIT_CODE=$?
+  fi
 
   if [[ ${EXIT_CODE} -ne 0 ]]; then
     echo -e "\033[31mPKG: ${PKG}; 'pub get' - FAILED  (${EXIT_CODE})\033[0m"
@@ -1034,7 +1037,10 @@ for PKG in ${PKGS}; do
     exit 64
   fi
 
-  pub upgrade --no-precompile || EXIT_CODE=$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z ${GITHUB_ACTIONS} ]]; then
+    pub upgrade --no-precompile || EXIT_CODE=$?
+  fi
 
   if [[ ${EXIT_CODE} -ne 0 ]]; then
     echo -e "PKG: ${PKG}; 'pub upgrade' - FAILED  (${EXIT_CODE})"

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -974,7 +974,7 @@ line 1, column 13 of mono_repo.yaml: Unsupported value for "pub_action". Value m
         await d.file(travisFileName, travisYamlOutput).validate();
         await d.file(ciScriptPath, contains(r'''
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
+  if [[ -z ${GITHUB_ACTIONS} ]] || [[ ! -z ${FORCE_PUB_COMMAND} ]]; then
     pub get --no-precompile || EXIT_CODE=$?
   fi
 
@@ -1038,7 +1038,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
+  if [[ -z ${GITHUB_ACTIONS} ]] || [[ ! -z ${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/mono_repo/test/script_integration_outputs/readme_ci.txt
+++ b/mono_repo/test/script_integration_outputs/readme_ci.txt
@@ -47,7 +47,10 @@ for PKG in ${PKGS}; do
     exit 64
   fi
 
-  pub upgrade --no-precompile || EXIT_CODE=$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z ${GITHUB_ACTIONS} ]]; then
+    pub upgrade --no-precompile || EXIT_CODE=$?
+  fi
 
   if [[ ${EXIT_CODE} -ne 0 ]]; then
     echo -e "\033[31mPKG: ${PKG}; 'pub upgrade' - FAILED  (${EXIT_CODE})\033[0m"

--- a/mono_repo/test/script_integration_outputs/readme_ci.txt
+++ b/mono_repo/test/script_integration_outputs/readme_ci.txt
@@ -48,7 +48,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
+  if [[ -z ${GITHUB_ACTIONS} ]] || [[ ! -z ${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/mono_repo/test/script_integration_outputs/readme_ci.txt
+++ b/mono_repo/test/script_integration_outputs/readme_ci.txt
@@ -48,7 +48,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z ${GITHUB_ACTIONS} ]]; then
+  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -35,9 +35,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: sub_pkg_pub_upgrade
+        name: "sub_pkg; pub upgrade --no-precompile"
+        run: "cd sub_pkg && pub upgrade --no-precompile"
+      - name: sub_pkg; pub run test
+        env:
           PKGS: sub_pkg
         run: tool/ci.sh test
+        if: "steps.sub_pkg_pub_upgrade.conclusion == 'success'"
   job_002:
     name: "cron; linux; `pub run test`"
     runs-on: ubuntu-latest
@@ -57,9 +62,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: sub_pkg_pub_upgrade
+        name: "sub_pkg; pub upgrade --no-precompile"
+        run: "cd sub_pkg && pub upgrade --no-precompile"
+      - name: sub_pkg; pub run test
+        env:
           PKGS: sub_pkg
         run: tool/ci.sh test
+        if: "steps.sub_pkg_pub_upgrade.conclusion == 'success'"
     if: "github.event_name == 'schedule'"
     needs:
       - job_001
@@ -72,9 +82,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: sub_pkg_pub_upgrade
+        name: "sub_pkg; pub.bat upgrade --no-precompile"
+        run: "cd sub_pkg && pub.bat upgrade --no-precompile"
+      - name: sub_pkg; pub run test
+        env:
           PKGS: sub_pkg
         run: tool/ci.sh test
+        if: "steps.sub_pkg_pub_upgrade.conclusion == 'success'"
     if: "github.event_name == 'schedule'"
     needs:
       - job_001

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -33,8 +33,10 @@ jobs:
           release-channel: stable
       - run: dart --version
       - uses: actions/checkout@v2
-      - run: pub global activate mono_repo 1.2.3
-      - run: pub global run mono_repo generate --validate
+      - name: mono_repo self validate
+        run: pub global activate mono_repo 1.2.3
+      - name: mono_repo self validate
+        run: pub global run mono_repo generate --validate
   job_002:
     name: "analyze; `dartanalyzer .`"
     runs-on: ubuntu-latest
@@ -54,9 +56,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: sub_pkg_pub_upgrade
+        name: "sub_pkg; pub upgrade --no-precompile"
+        run: "cd sub_pkg && pub upgrade --no-precompile"
+      - name: sub_pkg; dartanalyzer .
+        env:
           PKGS: sub_pkg
         run: tool/ci.sh dartanalyzer
+        if: "steps.sub_pkg_pub_upgrade.conclusion == 'success'"
   job_003:
     name: "analyze; `dartfmt -n --set-exit-if-changed .`"
     runs-on: ubuntu-latest
@@ -76,9 +83,14 @@ jobs:
           release-channel: dev
       - run: dart --version
       - uses: actions/checkout@v2
-      - env:
+      - id: sub_pkg_pub_upgrade
+        name: "sub_pkg; pub upgrade --no-precompile"
+        run: "cd sub_pkg && pub upgrade --no-precompile"
+      - name: "sub_pkg; dartfmt -n --set-exit-if-changed ."
+        env:
           PKGS: sub_pkg
         run: tool/ci.sh dartfmt
+        if: "steps.sub_pkg_pub_upgrade.conclusion == 'success'"
   job_004:
     name: Notify failure
     runs-on: ubuntu-latest

--- a/mono_repo/test/script_integration_test.dart
+++ b/mono_repo/test/script_integration_test.dart
@@ -152,6 +152,7 @@ void _registerTest(
       ],
       environment: {
         'PKGS': pkgsEnvironment,
+        'FORCE_PUB_COMMAND': '1',
       },
       workingDirectory: d.sandbox,
     );

--- a/mono_repo/test/src/expected_output.dart
+++ b/mono_repo/test/src/expected_output.dart
@@ -28,7 +28,10 @@ for PKG in ${PKGS}; do
     exit 64
   fi
 
-  pub upgrade --no-precompile || EXIT_CODE=$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z ${GITHUB_ACTIONS} ]]; then
+    pub upgrade --no-precompile || EXIT_CODE=$?
+  fi
 
   if [[ ${EXIT_CODE} -ne 0 ]]; then
     echo -e "\033[31mPKG: ${PKG}; 'pub upgrade' - FAILED  (${EXIT_CODE})\033[0m"

--- a/mono_repo/test/src/expected_output.dart
+++ b/mono_repo/test/src/expected_output.dart
@@ -29,7 +29,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
+  if [[ -z ${GITHUB_ACTIONS} ]] || [[ ! -z ${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/mono_repo/test/src/expected_output.dart
+++ b/mono_repo/test/src/expected_output.dart
@@ -29,7 +29,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z ${GITHUB_ACTIONS} ]]; then
+  if [[ -z \${GITHUB_ACTIONS} ]] || [[ ! -z \${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -47,7 +47,10 @@ for PKG in ${PKGS}; do
     exit 64
   fi
 
-  pub upgrade --no-precompile || EXIT_CODE=$?
+  # Github actions runs this as a separate "step" before we get into this script
+  if [[ -z ${GITHUB_ACTIONS} ]]; then
+    pub upgrade --no-precompile || EXIT_CODE=$?
+  fi
 
   if [[ ${EXIT_CODE} -ne 0 ]]; then
     echo -e "\033[31mPKG: ${PKG}; 'pub upgrade' - FAILED  (${EXIT_CODE})\033[0m"

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -48,7 +48,7 @@ for PKG in ${PKGS}; do
   fi
 
   # Github actions runs this as a separate "step" before we get into this script
-  if [[ -z ${GITHUB_ACTIONS} ]]; then
+  if [[ -z ${GITHUB_ACTIONS} ]] || [[ ! -z ${FORCE_PUB_COMMAND} ]]; then
     pub upgrade --no-precompile || EXIT_CODE=$?
   fi
 


### PR DESCRIPTION
Previously we would have a single step which might run multiple packages and/or commands on those packages, which makes the output hard to read.

This PR fixes that by doing the following:

- Adds a `pub` step for each package in a job, which runs the configured pub command
- Creates a separate step for each package/command combination, with an appropriate name
  - This step depends on its corresponding packages pub step
- Skips the pub command step in the `ci.sh` script on github actions.
  - unless you set the FORCE_PUB_COMMAND env variable, which is used for integration tests