### PR TITLE
Bump actions/checkout from 2 to 2.3.4

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -61,7 +61,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -106,7 +106,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -134,7 +134,7 @@ jobs:
         with:
           sdk: "2.10.4"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -166,7 +166,7 @@ jobs:
         with:
           sdk: "2.12.0-0.0.dev"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -198,7 +198,7 @@ jobs:
         with:
           sdk: "2.12.0-29.10.beta"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -230,7 +230,7 @@ jobs:
         with:
           sdk: beta
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -262,7 +262,7 @@ jobs:
         with:
           sdk: main
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -294,7 +294,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -326,7 +326,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -354,7 +354,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -392,7 +392,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -420,7 +420,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -458,7 +458,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -496,7 +496,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: mono_repo_pub_upgrade
         name: "mono_repo; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -534,7 +534,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: test_pkg_pub_upgrade
         name: "test_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Migrate code to null safety.
 - Require Dart 2.12.
 - Use latest `actions/cache@v2.1.5`.
+- Use latest `actions/checkout@v2.3.4`.
 
 ## 3.4.7
 

--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -340,7 +340,7 @@ Map<String, dynamic> _githubJobYaml(
         },
         {
           'id': 'checkout',
-          'uses': 'actions/checkout@v2',
+          'uses': 'actions/checkout@v2.3.4',
         },
         for (var command in runCommands) command.runContent,
       ],

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -34,7 +34,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: sub_pkg_pub_upgrade
         name: "sub_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -62,7 +62,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: sub_pkg_pub_upgrade
         name: "sub_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -83,7 +83,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: sub_pkg_pub_upgrade
         name: "sub_pkg; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -32,7 +32,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: mono_repo self validate
         run: pub global activate mono_repo 1.2.3
       - name: mono_repo self validate
@@ -55,7 +55,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: sub_pkg_pub_upgrade
         name: "sub_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -83,7 +83,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - id: sub_pkg_pub_upgrade
         name: "sub_pkg; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"


### PR DESCRIPTION
Closes https://github.com/google/mono_repo.dart/pull/321
