### PR TITLE
Support and encourage up-to-date task names

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.4;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.4;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:2.10.4;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:2.10.4
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-259.0.dev;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-259.0.dev;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-259.0.dev;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-259.0.dev
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-29.10.beta;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-29.10.beta;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-29.10.beta;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0-29.10.beta
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:mono_repo;commands:dartanalyzer_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:mono_repo;commands:analyze_1"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:mono_repo
             os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:beta;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:beta;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:beta;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:beta
@@ -207,7 +207,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo-test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo-test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:mono_repo-test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -252,7 +252,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:main;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:main;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:main;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:main
@@ -284,7 +284,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:test_pkg;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:test_pkg;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:test_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:stable

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - *BREAKING* Drop support for Travis-CI.
 - Change calls from `pub` to `dart pub` within generated scripts.
+- Support and encourage up-to-date task names:
+  - `analyze` instead of `dartanalyzer`
+  - `format` instead of `dartfmt`.
 
 ## 4.1.0
 
@@ -284,8 +287,8 @@ stages:
 stages:
   - analyze_and_format:
     - group:
-        - dartanalyzer
-        - dartfmt
+        - analyze
+        - format
 ```
 
 ## 0.3.0

--- a/mono_repo/README.md
+++ b/mono_repo/README.md
@@ -155,8 +155,8 @@ dart:
 stages:
   # Register two jobs to run under the `analyze` stage.
   - analyze:
-    - dartanalyzer
-    - dartfmt
+    - analyze
+    - format
   - unit_test:
     - test
   # Example cron stage which will only run for scheduled jobs (here we run

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -241,7 +241,7 @@ List<String> calculateOrderedStages(
     throw UserException(
       'Error parsing mono_repo.yaml',
       details: 'One or more stage was referenced in `mono_repo.yaml` that do '
-          'not exist in any `mono_pkg.yaml` files: $items.',
+          'not exist in any `$monoPkgFileName` files: $items.',
     );
   }
 

--- a/mono_repo/lib/src/ci_test_script.dart
+++ b/mono_repo/lib/src/ci_test_script.dart
@@ -7,20 +7,15 @@ import 'package_config.dart';
 import 'shell_utils.dart';
 import 'user_exception.dart';
 
-String _dartCommandContent(String commandName) => '''
-function $commandName() {
-  command $commandName "\$@"
-}''';
-
-String _dartCommandContentPub(String commandName) => '''
+String _commandContent(String commandName) => '''
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
 # then "flutter" is called instead of "pub".
 # This assumes that the Flutter SDK has been installed in a previous step.
 function $commandName() {
   if grep -Fq "sdk: flutter" "\${PWD}/pubspec.yaml"; then
-    command flutter pub "\$@"
+    command flutter $commandName "\$@"
   else
-    command dart pub "\$@"
+    command dart $commandName "\$@"
   fi
 }''';
 
@@ -29,9 +24,9 @@ final bashScriptHeader = '''
 $createdWith
 
 # Support built in commands on windows out of the box.
-${_dartCommandContentPub('pub')}
-${_dartCommandContent('dartfmt')}
-${_dartCommandContent('dartanalyzer')}''';
+${_commandContent('pub')}
+${_commandContent('format')}
+${_commandContent('analyze')}''';
 
 String generateTestScript(
   Map<String, String> commandsToKeys,

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -6,10 +6,10 @@ stages:
   - command: cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate
     dart: dev
   - group:
-    - dartfmt
-    - dartanalyzer: --fatal-infos .
+    - format
+    - analyze: --fatal-infos .
     dart: dev
-  - dartanalyzer:
+  - analyze:
     dart: 2.12.0
 - unit_test:
   - test: -x yaml -P presubmit --test-randomize-ordering-seed=random

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -246,9 +246,9 @@ dart:
 
 stages:
   - format:
-    - dartfmt
+    - format
   - analyze:
-    - dartanalyzer
+    - analyze
 '''),
       d.file('pubspec.yaml', '''
 name: pkg_a
@@ -262,9 +262,9 @@ dart:
 
 stages:
   - analyze:
-    - dartanalyzer
+    - analyze
   - format:
-    - dartfmt: sdk
+    - format: sdk
 '''),
       d.file('pubspec.yaml', '''
 name: pkg_b
@@ -371,7 +371,7 @@ dart:
 
 stages:
   - format:
-    - dartfmt
+    - format
 
 cache:
   directories:
@@ -390,7 +390,7 @@ dart:
 
 stages:
   - format:
-    - dartfmt: sdk
+    - format: sdk
 
 cache:
   directories:
@@ -416,7 +416,7 @@ $_writeScriptOutput''',
 
     await d.file(ciScriptPath, contains(r'''
       case ${TASK} in
-      dartfmt)
+      format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;
@@ -437,7 +437,7 @@ dart:
 
 stages:
   - format:
-    - dartfmt: sdk
+    - format: sdk
 
 cache:
   directories:
@@ -456,7 +456,7 @@ dart:
 
 stages:
   - format:
-    - dartfmt: --dry-run --fix --set-exit-if-changed .
+    - format: --dry-run --fix --set-exit-if-changed .
 
 cache:
   directories:
@@ -482,11 +482,11 @@ $_writeScriptOutput''',
 
     await d.file(ciScriptPath, contains(r'''
       case ${TASK} in
-      dartfmt_0)
+      format_0)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;
-      dartfmt_1)
+      format_1)
         echo 'dart format --dry-run --fix --set-exit-if-changed .'
         dart format --dry-run --fix --set-exit-if-changed . || EXIT_CODE=$?
         ;;
@@ -533,13 +533,13 @@ os:
 stages:
   - analyze:
     - group:
-        - dartanalyzer
-        - dartfmt
+        - analyze
+        - format
       dart:
         - dev
       os:
         - osx
-    - dartanalyzer:
+    - analyze:
       dart:
         - 1.23.0
       os:
@@ -752,8 +752,8 @@ dart:
 stages:
   - analyze:
     - group:
-        - dartanalyzer
-        - dartfmt
+        - analyze
+        - format
   - unit_test:
     - description: "chrome tests"
       test: --platform chrome
@@ -771,8 +771,8 @@ dart:
 stages:
   - analyze:
     - group:
-        - dartanalyzer
-        - dartfmt
+        - analyze
+        - format
   - unit_test:
     - description: "chrome tests"
       test: --platform chrome
@@ -874,7 +874,6 @@ line 1, column 14 of mono_repo.yaml: Unsupported value for "pretty_ansi". Value 
           printMatcher: _subPkgStandardOutput,
         );
 
-        // TODO: validate GitHub case
         await d
             .file(
                 ciScriptPath,
@@ -917,11 +916,11 @@ for PKG in ${PKGS}; do
       echo
       echo -e "PKG: ${PKG}; TASK: ${TASK}"
       case ${TASK} in
-      dartanalyzer)
+      analyze)
         echo 'dart analyze'
         dart analyze || EXIT_CODE=$?
         ;;
-      dartfmt)
+      format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -231,7 +231,7 @@ line 4, column 12: Unsupported value for "group". expected a list of tasks
       _expectParseThrows(
         monoYaml,
         r'''
-line 9, column 6: Must have one key of `dartfmt`, `dartanalyzer`, `test`, `command`.
+line 9, column 6: Must have one key of `format`, `analyze`, `test`, `command`.
   ╷
 9 │      "weird": "thing"
   │      ^^^^^^^
@@ -254,7 +254,7 @@ line 9, column 6: Must have one key of `dartfmt`, `dartanalyzer`, `test`, `comma
       _expectParseThrows(
         monoYaml,
         r'''
-line 10, column 6: Must have one and only one key of `dartfmt`, `dartanalyzer`, `test`, `command`.
+line 10, column 6: Must have one and only one key of `format`, `analyze`, `test`, `command`.
    ╷
 10 │      "command": "other thing"
    │      ^^^^^^^^^
@@ -445,8 +445,8 @@ List get _testConfig1expectedOutput => [
         'sdk': 'dev',
         'stageName': 'analyze_and_format',
         'tasks': [
-          {'name': 'dartanalyzer', 'args': '--fatal-infos --fatal-warnings .'},
-          {'name': 'dartfmt'}
+          {'name': 'analyze', 'args': '--fatal-infos --fatal-warnings .'},
+          {'name': 'format'}
         ]
       },
       {
@@ -456,8 +456,8 @@ List get _testConfig1expectedOutput => [
         'sdk': 'dev',
         'stageName': 'analyze_and_format',
         'tasks': [
-          {'name': 'dartanalyzer', 'args': '--fatal-infos --fatal-warnings .'},
-          {'name': 'dartfmt'}
+          {'name': 'analyze', 'args': '--fatal-infos --fatal-warnings .'},
+          {'name': 'format'}
         ]
       },
       {
@@ -466,7 +466,7 @@ List get _testConfig1expectedOutput => [
         'sdk': '1.23.0',
         'stageName': 'analyze_and_format',
         'tasks': [
-          {'name': 'dartanalyzer', 'args': '--fatal-infos --fatal-warnings .'}
+          {'name': 'analyze', 'args': '--fatal-infos --fatal-warnings .'}
         ]
       },
       {

--- a/mono_repo/test/presubmit_command_test.dart
+++ b/mono_repo/test/presubmit_command_test.dart
@@ -175,7 +175,7 @@ pkg_b
             'presubmit',
             '--sdk=dev',
             '-t',
-            'dartfmt'
+            'format'
           ],
           workingDirectory: repoPath);
       expect(result.exitCode, 0,
@@ -255,8 +255,8 @@ dart:
 
 stages:
   - analyze_and_format:
-    - dartanalyzer
-    - dartfmt
+    - analyze
+    - format
   - unit_test:
     - test
 ''';
@@ -268,7 +268,7 @@ dart:
 
 stages:
   - format:
-    - dartfmt
+    - format
 ''';
 
 const pkgAPubspec = '''

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -151,8 +151,8 @@ dart:
 stages:
   # Register two jobs to run under the `analyze` stage.
   - analyze:
-    - dartanalyzer
-    - dartfmt
+    - analyze
+    - format
   - unit_test:
     - test
   # Example cron stage which will only run for scheduled jobs (here we run

--- a/mono_repo/test/script_integration_outputs/all_packages_with_task_failures.txt
+++ b/mono_repo/test/script_integration_outputs/all_packages_with_task_failures.txt
@@ -2,11 +2,11 @@ PKG: pkg_a
 Resolving dependencies...
 No dependencies changed.
 
-PKG: pkg_a; TASK: dartanalyzer
+PKG: pkg_a; TASK: analyze
 dart analyze
 Analyzing pkg_a...
 No issues found!
-PKG: pkg_a; TASK: dartanalyzer - SUCCEEDED
+PKG: pkg_a; TASK: analyze - SUCCEEDED
 
 PKG: pkg_a; TASK: command_0
 echo "testing 1 2 3"
@@ -27,11 +27,11 @@ PKG: pkg_c
 Resolving dependencies...
 No dependencies changed.
 
-PKG: pkg_c; TASK: dartanalyzer
+PKG: pkg_c; TASK: analyze
 dart analyze
 Analyzing pkg_c...
 No issues found!
-PKG: pkg_c; TASK: dartanalyzer - SUCCEEDED
+PKG: pkg_c; TASK: analyze - SUCCEEDED
 
 PKG: pkg_c; TASK: command_0
 echo "testing 1 2 3"

--- a/mono_repo/test/script_integration_outputs/github_output_group_overrides.txt
+++ b/mono_repo/test/script_integration_outputs/github_output_group_overrides.txt
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:macos-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:dartanalyzer-dartfmt"
+          key: "os:macos-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:analyze-format"
           restore-keys: |
             os:macos-latest;pub-cache-hosted;dart:dev;packages:pkg_a
             os:macos-latest;pub-cache-hosted;dart:dev

--- a/mono_repo/test/script_integration_outputs/just_successes.txt
+++ b/mono_repo/test/script_integration_outputs/just_successes.txt
@@ -2,11 +2,11 @@ PKG: pkg_c
 Resolving dependencies...
 No dependencies changed.
 
-PKG: pkg_c; TASK: dartanalyzer
+PKG: pkg_c; TASK: analyze
 dart analyze
 Analyzing pkg_c...
 No issues found!
-PKG: pkg_c; TASK: dartanalyzer - SUCCEEDED
+PKG: pkg_c; TASK: analyze - SUCCEEDED
 
 PKG: pkg_c; TASK: command_0
 echo "testing 1 2 3"

--- a/mono_repo/test/script_integration_outputs/readme_ci.txt
+++ b/mono_repo/test/script_integration_outputs/readme_ci.txt
@@ -12,11 +12,25 @@ function pub() {
     command dart pub "$@"
   fi
 }
-function dartfmt() {
-  command dartfmt "$@"
+# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
+# then "flutter" is called instead of "pub".
+# This assumes that the Flutter SDK has been installed in a previous step.
+function format() {
+  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
+    command flutter format "$@"
+  else
+    command dart format "$@"
+  fi
 }
-function dartanalyzer() {
-  command dartanalyzer "$@"
+# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
+# then "flutter" is called instead of "pub".
+# This assumes that the Flutter SDK has been installed in a previous step.
+function analyze() {
+  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
+    command flutter analyze "$@"
+  else
+    command dart analyze "$@"
+  fi
 }
 
 if [[ -z ${PKGS} ]]; then
@@ -53,11 +67,11 @@ for PKG in ${PKGS}; do
       echo
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
-      dartanalyzer)
+      analyze)
         echo 'dart analyze'
         dart analyze || EXIT_CODE=$?
         ;;
-      dartfmt)
+      format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:analyze"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:dartfmt"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg;commands:format"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:sub_pkg
             os:ubuntu-latest;pub-cache-hosted;dart:dev

--- a/mono_repo/test/script_integration_outputs/should_merge_correctly.txt
+++ b/mono_repo/test/script_integration_outputs/should_merge_correctly.txt
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a-pkg_b;commands:dartanalyzer-dartfmt"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a-pkg_b;commands:analyze-format"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a-pkg_b
             os:ubuntu-latest;pub-cache-hosted;dart:stable

--- a/mono_repo/test/script_integration_outputs/two_dartfmt_flavors.txt
+++ b/mono_repo/test/script_integration_outputs/two_dartfmt_flavors.txt
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:dartfmt"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:format"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b;commands:dartfmt"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b;commands:format"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a;commands:dartfmt"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a;commands:format"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a
             os:ubuntu-latest;pub-cache-hosted;dart:stable

--- a/mono_repo/test/script_integration_outputs/two_dartfmt_flavors_different_args.txt
+++ b/mono_repo/test/script_integration_outputs/two_dartfmt_flavors_different_args.txt
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:dartfmt_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a;commands:format_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_a
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b;commands:dartfmt_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b;commands:format_1"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkg_b
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a;commands:dartfmt_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a;commands:format_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkg_a
             os:ubuntu-latest;pub-cache-hosted;dart:stable

--- a/mono_repo/test/script_integration_test.dart
+++ b/mono_repo/test/script_integration_test.dart
@@ -67,7 +67,7 @@ $ciScriptPathMessage''',
   _registerTest(
     'all packages with task failures',
     args: [
-      'dartanalyzer',
+      'analyze',
       'command_0',
     ],
     pkgsEnvironment: 'pkg_a pkg_b pkg_c',
@@ -77,7 +77,7 @@ $ciScriptPathMessage''',
   _registerTest(
     'just successes',
     args: [
-      'dartanalyzer',
+      'analyze',
       'command_0',
     ],
     pkgsEnvironment: 'pkg_c',
@@ -103,7 +103,7 @@ $ciScriptPathMessage''',
   _registerTest(
     'bad PKGS provided',
     args: [
-      'dartanalyzer',
+      'analyze',
       'command_0',
     ],
     pkgsEnvironment: 'pkg_d',
@@ -113,7 +113,7 @@ $ciScriptPathMessage''',
   _registerTest(
     'no PKGS set',
     args: [
-      'dartanalyzer',
+      'analyze',
       'command_0',
     ],
     pkgsEnvironment: '',
@@ -171,7 +171,7 @@ dart:
 
 stages:
   - stage1:
-    - dartanalyzer
+    - analyze
   - stage2:
     - command: echo "testing 1 2 3"
   - stage3:

--- a/mono_repo/test/shared.dart
+++ b/mono_repo/test/shared.dart
@@ -9,16 +9,12 @@ import 'package:checked_yaml/checked_yaml.dart';
 import 'package:mono_repo/src/ci_shared.dart';
 import 'package:mono_repo/src/commands/ci_script/generate.dart';
 import 'package:mono_repo/src/commands/generate.dart';
-import 'package:mono_repo/src/commands/github/generate.dart';
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/root_config.dart';
 import 'package:mono_repo/src/user_exception.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
-
-@Deprecated('kill me!')
-final travisFileName = defaultGitHubWorkflowFilePath;
 
 Future<void> populateConfig(String monoRepoContent) async {
   await d.file('mono_repo.yaml', monoRepoContent).create();
@@ -118,13 +114,13 @@ os:
 stages:
   - analyze:
     - group:
-        - dartanalyzer
-        - dartfmt
+        - analyze
+        - format
       dart:
         - dev
       os:
         - osx
-    - dartanalyzer:
+    - analyze:
       dart:
         - 1.23.0
       os:

--- a/mono_repo/test/src/expected_output.dart
+++ b/mono_repo/test/src/expected_output.dart
@@ -39,11 +39,11 @@ for PKG in ${PKGS}; do
       echo
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
-      dartanalyzer)
+      analyze)
         echo 'dart analyze'
         dart analyze || EXIT_CODE=$?
         ;;
-      dartfmt)
+      format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;

--- a/test_pkg/mono_pkg.yaml
+++ b/test_pkg/mono_pkg.yaml
@@ -5,8 +5,8 @@ dart:
 stages:
 - smoke_test:
   - group:
-    - dartfmt
-    - dartanalyzer: --fatal-infos .
+    - format
+    - analyze: --fatal-infos .
     dart:
     - beta
     - dev

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -12,11 +12,25 @@ function pub() {
     command dart pub "$@"
   fi
 }
-function dartfmt() {
-  command dartfmt "$@"
+# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
+# then "flutter" is called instead of "pub".
+# This assumes that the Flutter SDK has been installed in a previous step.
+function format() {
+  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
+    command flutter format "$@"
+  else
+    command dart format "$@"
+  fi
 }
-function dartanalyzer() {
-  command dartanalyzer "$@"
+# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
+# then "flutter" is called instead of "pub".
+# This assumes that the Flutter SDK has been installed in a previous step.
+function analyze() {
+  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
+    command flutter analyze "$@"
+  else
+    command dart analyze "$@"
+  fi
 }
 
 if [[ -z ${PKGS} ]]; then
@@ -53,19 +67,19 @@ for PKG in ${PKGS}; do
       echo
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
+      analyze_0)
+        echo 'dart analyze --fatal-infos .'
+        dart analyze --fatal-infos . || EXIT_CODE=$?
+        ;;
+      analyze_1)
+        echo 'dart analyze'
+        dart analyze || EXIT_CODE=$?
+        ;;
       command)
         echo 'cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate'
         cd ../ && dart mono_repo/bin/mono_repo.dart generate --validate || EXIT_CODE=$?
         ;;
-      dartanalyzer_0)
-        echo 'dart analyze --fatal-infos .'
-        dart analyze --fatal-infos . || EXIT_CODE=$?
-        ;;
-      dartanalyzer_1)
-        echo 'dart analyze'
-        dart analyze || EXIT_CODE=$?
-        ;;
-      dartfmt)
+      format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
         ;;


### PR DESCRIPTION
`analyze` instead of `dartanalyzer`
`format` instead of `dartfmt`.

Warn when the old names are used.