### PR TITLE
Mark mono_repo outputs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github/workflows/dart.yml linguist-generated=true
+tool/ci.sh linguist-generated=true


### PR DESCRIPTION
Keeps the noisy diff collapsed in github reviews.
