### PR TITLE
Update readme_command.dart

### DIFF
--- a/mono_repo/lib/src/commands/readme_command.dart
+++ b/mono_repo/lib/src/commands/readme_command.dart
@@ -46,11 +46,11 @@ String readme(
   required bool pad,
 }) {
   final rows = [
-    ['Package source', 'Description', 'Published Version'],
+    ['Package', 'Description', 'Version'],
     for (var pkg in enumeratePackages(rootConfig, onlyPublished: onlyPublished))
       [
         '[${pkg.pubspec.name}](${pkg.relativePath}/)',
-        pkg.pubspec.description ?? '',
+        pkg.pubspec.description?.trim() ?? '',
         pkg.pubspec.pubBadge,
       ]
   ];

--- a/mono_repo/test/readme_command_test.dart
+++ b/mono_repo/test/readme_command_test.dart
@@ -15,7 +15,7 @@ void main() {
           pad: false,
         ),
         '''
-| Package source | Description | Published Version |
+| Package | Description | Version |
 |---|---|---|
 | [pkg1](pkg1_dir/) |  |  |
 | [pkg2](pkg2_dir/) |  |  |
@@ -31,7 +31,7 @@ void main() {
         pad: true,
       ),
       '''
-| Package source    | Description | Published Version                                                                      |
+| Package           | Description | Version                                                                                |
 |-------------------|-------------|----------------------------------------------------------------------------------------|
 | [pkg1](pkg1_dir/) |             |                                                                                        |
 | [pkg2](pkg2_dir/) |             |                                                                                        |
@@ -48,7 +48,7 @@ void main() {
         pad: false,
       ),
       '''
-| Package source | Description | Published Version |
+| Package | Description | Version |
 |---|---|---|
 | [pkg3](pkg3_dir/) |  | [![pub package](https://img.shields.io/pub/v/pkg3.svg)](https://pub.dev/packages/pkg3) |
 | [pkg4](pkg4_dir/) |  | [![pub package](https://img.shields.io/pub/v/pkg4.svg)](https://pub.dev/packages/pkg4) |''',


### PR DESCRIPTION
A follow up from https://github.com/dart-lang/shelf/pull/236 - remove training newlines from the package description.

(feel free to revert the `'Package', 'Description', 'Version'` tweaks)
