### PR TITLE
Add support for `pubspec` as an SDK target

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -85,23 +85,23 @@ jobs:
         if: "always() && steps.test_pkg_pub_upgrade.conclusion == 'success'"
         working-directory: test_pkg
   job_003:
-    name: "smoke_test; linux; Dart 2.17.5; PKG: mono_repo; `dart analyze`"
+    name: "smoke_test; linux; Dart 2.17.0; PKG: mono_repo; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5;packages:mono_repo;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:mono_repo;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5;packages:mono_repo
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.5"
+          sdk: "2.17.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
@@ -430,23 +430,23 @@ jobs:
         if: "always() && steps.test_pkg_pub_upgrade.conclusion == 'success'"
         working-directory: test_pkg
   job_013:
-    name: "test; linux; Dart 2.17.5; PKG: mono_repo; `dart test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "test; linux; Dart 2.17.0; PKG: mono_repo; `dart test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5;packages:mono_repo;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:mono_repo;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5;packages:mono_repo
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.5
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:mono_repo
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.5"
+          sdk: "2.17.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
@@ -776,13 +776,13 @@ jobs:
       - job_011
       - job_012
   job_020:
-    name: "test; windows; Dart 2.17.5; PKG: mono_repo; `dart test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
+    name: "test; windows; Dart 2.17.0; PKG: mono_repo; `dart test -x yaml -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "2.17.5"
+          sdk: "2.17.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,9 +1,10 @@
-
 ## 6.4.0-dev
 
 - Added support for `test_with_coverage`.
   Uses `package:coverage` and supports [Coveralls](https://coveralls.io)
   (the default) and [Codecov](https://codecov.com/) to track test code coverage.
+- Added support for `pubspec` as an CI target for Dart packages. When used,
+  the lower-bound of the support SDK range is used.
 - Added `--verbose` flag. Helps when debugging failures.
 
 ## 6.3.0

--- a/mono_repo/README.md
+++ b/mono_repo/README.md
@@ -170,6 +170,9 @@ details on how you'd like tests to be run.
 # an array. Alternatively, you can specify the SDK version(s) within each job.
 sdk:
  - dev
+ # Specific `pubspec` to test the lower-bound SDK defined in pubspec.yaml
+ # This is only supported for Dart packages (not Flutter).
+ - pubspec
 
 stages:
   # Register two jobs to run under the `analyze` stage.

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -83,7 +83,7 @@ class PackageConfig {
 
     final flavor = pubspec.flavor;
 
-    final rawConfig = RawConfig.fromYaml(flavor, monoPkgYaml);
+    final rawConfig = RawConfig.fromYaml(flavor, monoPkgYaml, pubspec);
 
     // FYI: 'test' is default if there are no tasks defined
     final jobs = <CIJob>[];
@@ -102,6 +102,12 @@ class PackageConfig {
               ? jobSdks = List.from(jobValue)
               : [jobValue as String];
 
+          handlePubspecInSdkList(
+            flavor,
+            jobSdks,
+            pubspec,
+            (m) => CheckedFromJsonException(job, 'sdk', 'RawConfig', m),
+          );
           sortNormalizeVerifySdksList(
             flavor,
             jobSdks,

--- a/mono_repo/lib/src/raw_config.dart
+++ b/mono_repo/lib/src/raw_config.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'package_flavor.dart';
 import 'utilities.dart';
@@ -42,10 +43,17 @@ class RawConfig {
     oses.sort();
   }
 
-  factory RawConfig.fromYaml(PackageFlavor flavor, Map json) {
+  factory RawConfig.fromYaml(PackageFlavor flavor, Map json, Pubspec pubspec) {
     final config = runZoned(
       () => _$RawConfigFromJson(json),
       zoneValues: {_flavorKey: flavor},
+    );
+
+    handlePubspecInSdkList(
+      flavor,
+      config.sdks,
+      pubspec,
+      (m) => CheckedFromJsonException(json, 'sdk', 'RawConfig', m),
     );
 
     final stages = <String>{};

--- a/mono_repo/lib/src/utilities.dart
+++ b/mono_repo/lib/src/utilities.dart
@@ -14,7 +14,7 @@ const githubSetupMainSdk = 'main';
 
 /// SDK version key to tell the generator to align with what's defined in
 /// the pubspec.
-const pubspecSdkKey = 'pubspec';
+const _pubspecSdkKey = 'pubspec';
 
 String? errorForSdkConfig(PackageFlavor flavor, String sdk) {
   try {
@@ -40,7 +40,7 @@ String? errorForSdkConfig(PackageFlavor flavor, String sdk) {
   }
 }
 
-/// Replaces instances of [pubspecSdkKey] in [sdks] with the lower-bound
+/// Replaces instances of [_pubspecSdkKey] in [sdks] with the lower-bound
 /// SDK constraint from [pubspec].
 void handlePubspecInSdkList(
   PackageFlavor flavor,
@@ -61,11 +61,11 @@ void handlePubspecInSdkList(
 
   for (var i = 0; i < sdks.length; i++) {
     final startValue = sdks[i];
-    if (startValue == pubspecSdkKey) {
+    if (startValue == _pubspecSdkKey) {
       if (flavor != PackageFlavor.dart) {
         // ignore: only_throw_errors
         throw errorFactory(
-          '`$pubspecSdkKey` is only valid for Dart packages (not Flutter).',
+          '`$_pubspecSdkKey` is only valid for Dart packages (not Flutter).',
         );
       }
 
@@ -76,7 +76,7 @@ void handlePubspecInSdkList(
         //   the supported types
         // ignore: only_throw_errors
         throw errorFactory(
-          '`$pubspecSdkKey` is only valid for packages that have an '
+          '`$_pubspecSdkKey` is only valid for packages that have an '
           'environment->sdk value defined in `pubspec.yaml`.',
         );
       }
@@ -116,7 +116,7 @@ const _supportedFlutterSdkLiterals = {
 
 const _supportedDartSdkLiterals = {
   githubSetupMainSdk,
-  pubspecSdkKey,
+  _pubspecSdkKey,
   'dev',
   'beta',
   'stable',

--- a/mono_repo/lib/src/utilities.dart
+++ b/mono_repo/lib/src/utilities.dart
@@ -12,6 +12,10 @@ const travisEdgeSdk = 'be/raw/latest';
 /// Maps to `be/raw/latest` or "bleeding edge".
 const githubSetupMainSdk = 'main';
 
+/// SDK version key to tell the generator to align with what's defined in
+/// the pubspec.
+const pubspecSdkKey = 'pubspec';
+
 String? errorForSdkConfig(PackageFlavor flavor, String sdk) {
   try {
     Version.parse(sdk);
@@ -32,6 +36,50 @@ String? errorForSdkConfig(PackageFlavor flavor, String sdk) {
         return null;
       default:
         throw UnsupportedError('should never get a flavor of `$flavor`');
+    }
+  }
+}
+
+/// Replaces instances of [pubspecSdkKey] in [sdks] with the lower-bound
+/// SDK constraint from [pubspec].
+void handlePubspecInSdkList(
+  PackageFlavor flavor,
+  List<String>? sdks,
+  Pubspec pubspec,
+  Object Function(String message) errorFactory,
+) {
+  if (sdks == null) {
+    return;
+  }
+
+  final sdkConstraint = pubspec.environment?['sdk'];
+
+  Version? lowerVersion;
+  if (sdkConstraint is VersionRange && sdkConstraint.includeMin) {
+    lowerVersion = sdkConstraint.min;
+  }
+
+  for (var i = 0; i < sdks.length; i++) {
+    final startValue = sdks[i];
+    if (startValue == pubspecSdkKey) {
+      if (flavor != PackageFlavor.dart) {
+        // ignore: only_throw_errors
+        throw errorFactory(
+          '`$pubspecSdkKey` is only valid for Dart packages (not Flutter).',
+        );
+      }
+
+      if (lowerVersion != null) {
+        sdks[i] = lowerVersion.toString();
+      } else {
+        // TODO: throw a more specific error when the SDK constraint is not of
+        //   the supported types
+        // ignore: only_throw_errors
+        throw errorFactory(
+          '`$pubspecSdkKey` is only valid for packages that have an '
+          'environment->sdk value defined in `pubspec.yaml`.',
+        );
+      }
     }
   }
 }
@@ -68,6 +116,7 @@ const _supportedFlutterSdkLiterals = {
 
 const _supportedDartSdkLiterals = {
   githubSetupMainSdk,
+  pubspecSdkKey,
   'dev',
   'beta',
   'stable',

--- a/mono_repo/mono_pkg.yaml
+++ b/mono_repo/mono_pkg.yaml
@@ -10,13 +10,13 @@ stages:
     - analyze: --fatal-infos .
     sdk: dev
   - analyze:
-    sdk: 2.17.5
+    sdk: pubspec
 - test:
   - test: -x yaml -P presubmit --test-randomize-ordering-seed=random
     os:
     - linux
     - windows
-    sdk: [2.17.5]
+    sdk: [pubspec]
   - test_with_coverage: -x yaml -P presubmit --test-randomize-ordering-seed=random
     os:
     - linux

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -374,7 +374,7 @@ line 12, column 4: Stages must be unique. "a" appears more than once.
       };
 
       _expectParseThrows(monoYaml, r'''
-line 2, column 9: Unsupported value for "sdk". The value "latest" is neither a version string nor one of "main", "dev", "beta", "stable".
+line 2, column 9: Unsupported value for "sdk". The value "latest" is neither a version string nor one of "main", "pubspec", "dev", "beta", "stable".
   ╷
 2 │    "sdk": [
   │ ┌─────────^

--- a/mono_repo/test/readme_test.dart
+++ b/mono_repo/test/readme_test.dart
@@ -33,6 +33,8 @@ void main() {
         d.file(monoPkgFileName, _pkgYaml),
         d.file('pubspec.yaml', '''
 name: sub_pkg
+environment:
+  sdk: '>=2.17.0 <3.0.0'
 ''')
       ]).create();
 
@@ -161,6 +163,9 @@ const _pkgYaml = r'''
 # an array. Alternatively, you can specify the SDK version(s) within each job.
 sdk:
  - dev
+ # Specific `pubspec` to test the lower-bound SDK defined in pubspec.yaml
+ # This is only supported for Dart packages (not Flutter).
+ - pubspec
 
 stages:
   # Register two jobs to run under the `analyze` stage.

--- a/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_defaults.txt
@@ -18,7 +18,37 @@ permissions: read-all
 
 jobs:
   job_001:
-    name: "unit_test; linux; `dart test`"
+    name: "unit_test; linux; Dart 2.17.0; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: sub_pkg_pub_upgrade
+        name: sub_pkg; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: sub_pkg
+      - name: sub_pkg; dart test
+        run: dart test
+        if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
+        working-directory: sub_pkg
+  job_002:
+    name: "unit_test; linux; Dart dev; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -47,8 +77,42 @@ jobs:
         run: dart test
         if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
         working-directory: sub_pkg
-  job_002:
-    name: "cron; linux; `dart test`"
+  job_003:
+    name: "cron; linux; Dart 2.17.0; `dart test`"
+    runs-on: ubuntu-latest
+    if: "github.event_name == 'schedule'"
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: sub_pkg_pub_upgrade
+        name: sub_pkg; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: sub_pkg
+      - name: sub_pkg; dart test
+        run: dart test
+        if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
+        working-directory: sub_pkg
+    needs:
+      - job_001
+      - job_002
+  job_004:
+    name: "cron; linux; Dart dev; `dart test`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
     steps:
@@ -80,8 +144,33 @@ jobs:
         working-directory: sub_pkg
     needs:
       - job_001
-  job_003:
-    name: "cron; windows; `dart test`"
+      - job_002
+  job_005:
+    name: "cron; windows; Dart 2.17.0; `dart test`"
+    runs-on: windows-latest
+    if: "github.event_name == 'schedule'"
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: sub_pkg_pub_upgrade
+        name: sub_pkg; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: sub_pkg
+      - name: sub_pkg; dart test
+        run: dart test
+        if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
+        working-directory: sub_pkg
+    needs:
+      - job_001
+      - job_002
+  job_006:
+    name: "cron; windows; Dart dev; `dart test`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
     steps:
@@ -103,7 +192,8 @@ jobs:
         working-directory: sub_pkg
     needs:
       - job_001
-  job_004:
+      - job_002
+  job_007:
     name: Notify failure
     runs-on: ubuntu-latest
     if: failure()
@@ -118,3 +208,6 @@ jobs:
       - job_001
       - job_002
       - job_003
+      - job_004
+      - job_005
+      - job_006

--- a/mono_repo/test/script_integration_outputs/readme_github_lints.txt
+++ b/mono_repo/test/script_integration_outputs/readme_github_lints.txt
@@ -41,7 +41,67 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze; `dart analyze`"
+    name: "analyze; Dart 2.17.0; `dart analyze`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: sub_pkg_pub_upgrade
+        name: sub_pkg; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: sub_pkg
+      - name: sub_pkg; dart analyze
+        run: dart analyze
+        if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
+        working-directory: sub_pkg
+  job_003:
+    name: "analyze; Dart 2.17.0; `dart format --output=none --set-exit-if-changed .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg;commands:format"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:sub_pkg
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.17.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: sub_pkg_pub_upgrade
+        name: sub_pkg; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: sub_pkg
+      - name: "sub_pkg; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
+        working-directory: sub_pkg
+  job_004:
+    name: "analyze; Dart dev; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -70,8 +130,8 @@ jobs:
         run: dart analyze
         if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
         working-directory: sub_pkg
-  job_003:
-    name: "analyze; `dart format --output=none --set-exit-if-changed .`"
+  job_005:
+    name: "analyze; Dart dev; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -100,7 +160,7 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.sub_pkg_pub_upgrade.conclusion == 'success'"
         working-directory: sub_pkg
-  job_004:
+  job_006:
     name: Notify failure
     runs-on: ubuntu-latest
     if: failure()
@@ -115,3 +175,5 @@ jobs:
       - job_001
       - job_002
       - job_003
+      - job_004
+      - job_005

--- a/mono_repo/test/script_integration_outputs/valid_pubspec_version.txt
+++ b/mono_repo/test/script_integration_outputs/valid_pubspec_version.txt
@@ -1,0 +1,290 @@
+# Created with package:mono_repo v1.2.3
+name: Dart CI
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+defaults:
+  run:
+    shell: bash
+env:
+  PUB_ENVIRONMENT: bot.github
+permissions: read-all
+
+jobs:
+  job_001:
+    name: "analyze_and_format; linux; Dart 2.16.0; `dart analyze`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a;commands:analyze_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.16.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: pkg_a; dart analyze
+        run: dart analyze
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+  job_002:
+    name: "analyze_and_format; linux; Dart dev; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a;commands:analyze_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+  job_003:
+    name: "analyze_and_format; linux; Dart dev; `dart format --output=none --set-exit-if-changed .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a;commands:format"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+  job_004:
+    name: "unit_test; linux; Dart 2.16.0; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.16.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003
+  job_005:
+    name: "unit_test; linux; Dart 2.16.0; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.16.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.16.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003
+  job_006:
+    name: "unit_test; linux; Dart dev; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a;commands:test_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003
+  job_007:
+    name: "unit_test; linux; Dart dev; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@4504faf7e9bcf8f3ed0bc863c4e1d21499ab8ef8
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkg_a
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003
+  job_008:
+    name: "unit_test; windows; Dart 2.16.0; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.16.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003
+  job_009:
+    name: "unit_test; windows; Dart dev; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28
+      - id: pkg_a_pub_upgrade
+        name: pkg_a; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkg_a
+      - name: "pkg_a; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.pkg_a_pub_upgrade.conclusion == 'success'"
+        working-directory: pkg_a
+    needs:
+      - job_001
+      - job_002
+      - job_003

--- a/test_pkg/mono_pkg.yaml
+++ b/test_pkg/mono_pkg.yaml
@@ -12,7 +12,7 @@ stages:
     - dev
     - edge
     - stable
-    - 2.16.0
+    - pubspec
     - 2.17.0-69.1.beta
     - 2.18.0-106.0.dev
 - test:


### PR DESCRIPTION
Replaced by the lower-bound of the environment->sdk value in the pubspec
Means there's less find-replace crazy when bumping the min SDK
Only works with Dart (not Flutter) packages
