### PR TITLE
Restore ordering of jobs to what it was before

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.5.5
+# Created with package:mono_repo v6.5.6
 name: Dart CI
 on:
   push:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.5.6
+
+- Restore the previous ordering behavior for jobs by using a secondary sort
+  based on the insertion order (this matches the listed configuration order).
+
 ## 6.5.5
 
 - Add the pub package topics `tool` and `repository-management`.

--- a/mono_repo/lib/src/ci_shared.dart
+++ b/mono_repo/lib/src/ci_shared.dart
@@ -257,6 +257,8 @@ List<String> calculateOrderedStages(
     };
 
     // Orders by dependencies first, and detect cycles (which aren't allowed).
+    // Our edges here are actually reverse edges already, so a topological sort
+    // gives us the right thing.
     components = topologicalSort(
       keys,
       (n) => edges[n]!,
@@ -270,14 +272,12 @@ List<String> calculateOrderedStages(
     );
   }
 
-  final orderedStages = components;
-
   if (rootConfig.monoConfig.selfValidateStage != null &&
-      !orderedStages.contains(rootConfig.monoConfig.selfValidateStage)) {
-    orderedStages.insert(0, rootConfig.monoConfig.selfValidateStage!);
+      !components.contains(rootConfig.monoConfig.selfValidateStage)) {
+    components.insert(0, rootConfig.monoConfig.selfValidateStage!);
   }
 
-  return orderedStages;
+  return components;
 }
 
 List<Task> _travisTasks(Iterable<PackageConfig> configs) =>

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.5.5';
+const packageVersion = '6.5.6';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 6.5.5
+version: 6.5.6
 repository: https://github.com/google/mono_repo.dart
 topics:
  - tool
@@ -15,7 +15,7 @@ dependencies:
   args: ^2.0.0
   checked_yaml: ^2.0.0
   collection: ^1.14.3
-  graphs: ^2.0.0
+  graphs: ^2.2.0
   io: ^1.0.0
   json_annotation: ^4.8.0
   meta: ^1.0.0

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.5.5
+# Created with package:mono_repo v6.5.6
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
The latest package:graphs changed its ordering for things where the ordering isn't specified.

This uses a secondary sort to restore the order for non-dependent stages/jobs so that they go in insertion order, which is the order in which they were listed in the configs (and also matches the old order).   