### PR TITLE
feat: add root cascading defaults, ignore list, and task hooks (Stage 2)

### DIFF
--- a/mono_repo/lib/src/commands/github/github_yaml.dart
+++ b/mono_repo/lib/src/commands/github/github_yaml.dart
@@ -4,6 +4,8 @@
 
 import 'dart:collection';
 
+import 'package:path/path.dart' as p;
+
 import '../../basic_config.dart';
 import '../../ci_shared.dart';
 import '../../github_config.dart';
@@ -296,9 +298,11 @@ extension on CIJobEntry {
 
     final commandEntries = <_CommandEntry>[];
     for (var package in packages) {
-      final pubStepId =
-          '${package.replaceAll('/', '_')}_'
-          'pub_${rootConfig.monoConfig.pubAction}';
+      final posixPkg = p.posix.joinAll(p.split(package));
+      final safePkg = (posixPkg == '.' || posixPkg.isEmpty)
+          ? 'root'
+          : posixPkg.replaceAll('/', '_');
+      final pubStepId = '${safePkg}_pub_${rootConfig.monoConfig.pubAction}';
       commandEntries.add(
         _CommandEntry(
           '$package; $pubCommand',
@@ -327,6 +331,10 @@ extension on CIJobEntry {
       }
     }
 
+    final packageConfig = rootConfig.singleWhere(
+      (p) => p.relativePath == job.package,
+    );
+
     return _githubJob(
       jobName(
         packages,
@@ -345,6 +353,8 @@ extension on CIJobEntry {
         'packages': packages.join('-'),
         'commands': commands.join('-'),
       },
+      preSteps: packageConfig.preSteps,
+      postSteps: packageConfig.postSteps,
     );
   }
 
@@ -386,9 +396,13 @@ Job _githubJob(
   RootConfig rootConfig, {
   required BasicConfiguration config,
   Map<String, String>? additionalCacheKeys,
+  Map<String, dynamic>? strategy,
+  List<Map>? preSteps,
+  List<Map>? postSteps,
 }) => Job(
   name: jobName,
   runsOn: runsOn,
+  strategy: strategy,
   steps: [
     if (!runsOn.startsWith('windows'))
       _cacheEntries(
@@ -400,6 +414,7 @@ Job _githubJob(
         },
       ),
     packageFlavor.setupStep(sdkVersion, rootConfig),
+    if (preSteps != null) ...preSteps.map(Step.fromJson),
     ..._beforeSteps(runCommands.whereType<_CommandEntry>()),
     ActionInfo.checkout.usage(
       id: 'checkout',
@@ -407,6 +422,7 @@ Job _githubJob(
       withContent: {'persist-credentials': false},
     ),
     for (var command in runCommands) ...command.runContent(config, rootConfig),
+    if (postSteps != null) ...postSteps.map(Step.fromJson),
   ],
 );
 

--- a/mono_repo/lib/src/commands/github/job.dart
+++ b/mono_repo/lib/src/commands/github/job.dart
@@ -20,8 +20,9 @@ class Job implements YamlLike {
   @JsonKey(required: true)
   final List<Step> steps;
   List<String>? needs;
+  final Map<String, dynamic>? strategy;
 
-  Job({this.name, this.runsOn, required this.steps});
+  Job({this.name, this.runsOn, required this.steps, this.strategy});
 
   factory Job.fromJson(Map json) => _$JobFromJson(json);
 

--- a/mono_repo/lib/src/commands/github/job.g.dart
+++ b/mono_repo/lib/src/commands/github/job.g.dart
@@ -17,6 +17,10 @@ Job _$JobFromJson(Map json) => $checkedCreate('Job', json, ($checkedConvert) {
       'steps',
       (v) => (v as List<dynamic>).map((e) => Step.fromJson(e as Map)).toList(),
     ),
+    strategy: $checkedConvert(
+      'strategy',
+      (v) => (v as Map?)?.map((k, e) => MapEntry(k as String, e)),
+    ),
   );
   $checkedConvert('if', (v) => val.ifContent = v as String?);
   $checkedConvert(
@@ -32,4 +36,5 @@ Map<String, dynamic> _$JobToJson(Job instance) => <String, dynamic>{
   'if': ?instance.ifContent,
   'steps': instance.steps.map((e) => e.toJson()).toList(),
   'needs': ?instance.needs,
+  'strategy': ?instance.strategy,
 };

--- a/mono_repo/lib/src/mono_config.dart
+++ b/mono_repo/lib/src/mono_config.dart
@@ -21,6 +21,8 @@ const _allowedMonoConfigKeys = {
   'pub_action',
   'self_validate',
   'coverage_service',
+  'defaults',
+  'ignore',
 };
 
 const _defaultPubAction = 'upgrade';
@@ -34,6 +36,8 @@ class MonoConfig implements BasicConfiguration {
   final String pubAction;
   final String? selfValidateStage;
   final GitHubConfig github;
+  final Map<String, dynamic> defaults;
+  final Set<String> ignore;
   @override
   final Set<CoverageProcessor> coverageProcessors;
 
@@ -43,6 +47,8 @@ class MonoConfig implements BasicConfiguration {
     required this.pubAction,
     required this.selfValidateStage,
     required Map github,
+    required this.defaults,
+    required this.ignore,
     required this.coverageProcessors,
   }) : githubConditionalStages = _readConditionalStages(github),
        github = GitHubConfig.fromJson(github);
@@ -122,12 +128,30 @@ class MonoConfig implements BasicConfiguration {
 
     final coverageServices = _asList(json, 'coverage_service');
 
+    var defaults = <String, dynamic>{};
+    final rawDefaults = json['defaults'];
+    if (rawDefaults != null) {
+      if (rawDefaults is! Map) {
+        throw CheckedFromJsonException(
+          json,
+          'defaults',
+          'MonoConfig',
+          '`defaults` must be a Map.',
+        );
+      }
+      defaults = Map<String, dynamic>.from(rawDefaults);
+    }
+
+    final ignore = _asList(json, 'ignore').toSet();
+
     return MonoConfig._(
       mergeStages: Set.from(mergeStages),
       prettyAnsi: prettyAnsi,
       pubAction: pubAction,
       selfValidateStage: _selfValidateFromValue(selfValidate),
       github: github,
+      defaults: defaults,
+      ignore: ignore,
       coverageProcessors: coverageServices
           .map((e) => CoverageProcessor.values.byName(e))
           .toSet(),
@@ -145,6 +169,8 @@ class MonoConfig implements BasicConfiguration {
         prettyAnsi: true,
         selfValidateStage: null,
         github: {},
+        defaults: {},
+        ignore: const {},
         coverageProcessors: {CoverageProcessor.coveralls},
       );
     }

--- a/mono_repo/lib/src/package_config.dart
+++ b/mono_repo/lib/src/package_config.dart
@@ -30,6 +30,8 @@ class PackageConfig {
   final List<String> cacheDirectories;
   final bool dartSdkConfigUsed;
   final bool osConfigUsed;
+  final List<Map>? preSteps;
+  final List<Map>? postSteps;
 
   PackageConfig(
     this.relativePath,
@@ -41,6 +43,8 @@ class PackageConfig {
     this.cacheDirectories,
     this.dartSdkConfigUsed,
     this.osConfigUsed,
+    this.preSteps,
+    this.postSteps,
   ) : assert(() {
         if (sdks == null) return true;
         sortNormalizeVerifySdksList(pubspec.flavor, sdks, AssertionError.new);
@@ -50,17 +54,24 @@ class PackageConfig {
   factory PackageConfig.parse(
     String relativePath,
     Pubspec pubspec,
-    Map monoPkgYaml,
-  ) => createWithCheck(
-    () => PackageConfig._parse(relativePath, pubspec, monoPkgYaml),
+    Map monoPkgYaml, {
+    Map<String, dynamic>? defaults,
+  }) => createWithCheck(
+    () => PackageConfig._parse(
+      relativePath,
+      pubspec,
+      monoPkgYaml,
+      defaults: defaults,
+    ),
   );
 
   factory PackageConfig._parse(
     String relativePath,
     Pubspec pubspec,
-    Map monoPkgYaml,
-  ) {
-    if (monoPkgYaml.isEmpty) {
+    Map monoPkgYaml, {
+    Map<String, dynamic>? defaults,
+  }) {
+    if (monoPkgYaml.isEmpty && (defaults == null || defaults.isEmpty)) {
       // It's valid to have an empty `mono_pkg.yaml` file – it just results in
       // an empty config WRT travis.
       return PackageConfig(
@@ -73,12 +84,40 @@ class PackageConfig {
         [],
         false,
         false,
+        null,
+        null,
       );
     }
 
     final flavor = pubspec.flavor;
 
-    final rawConfig = RawConfig.fromYaml(flavor, monoPkgYaml, pubspec);
+    // Note: This is a shallow merge.
+    // If a package specifies `stages` or `cache`, it completely overwrites
+    // the values from `defaults` rather than deep merging them.
+    final mergedConfig = <String, dynamic>{};
+    if (defaults != null) {
+      mergedConfig.addAll(defaults.cast<String, dynamic>());
+    }
+    mergedConfig.addAll(monoPkgYaml.cast<String, dynamic>());
+    if (monoPkgYaml is YamlMap) {
+      setYamlMapContext(mergedConfig, monoPkgYaml);
+    }
+
+    final rawConfig = RawConfig.fromYaml(flavor, mergedConfig);
+
+    if (rawConfig.sdks != null) {
+      handlePubspecInSdkList(
+        flavor,
+        rawConfig.sdks!,
+        pubspec,
+        (m) => CheckedFromJsonException(monoPkgYaml, 'sdk', 'RawConfig', m),
+      );
+      sortNormalizeVerifySdksList(
+        flavor,
+        rawConfig.sdks!,
+        (m) => CheckedFromJsonException(monoPkgYaml, 'sdk', 'RawConfig', m),
+      );
+    }
 
     // FYI: 'test' is default if there are no tasks defined
     final jobs = <CIJob>[];
@@ -92,7 +131,7 @@ class PackageConfig {
         var jobSdks = rawConfig.sdks;
         if (job case {'sdk': final jobValue}) {
           jobSdks = (jobValue is List)
-              ? jobSdks = List.from(jobValue)
+              ? List.from(jobValue)
               : [jobValue as String];
 
           handlePubspecInSdkList(
@@ -195,6 +234,8 @@ class PackageConfig {
       rawConfig.cache?.directories ?? const [],
       sdkConfigUsed,
       osConfigUsed,
+      rawConfig.preSteps,
+      rawConfig.postSteps,
     );
   }
 }

--- a/mono_repo/lib/src/raw_config.dart
+++ b/mono_repo/lib/src/raw_config.dart
@@ -5,10 +5,8 @@
 import 'dart:async';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'package_flavor.dart';
-import 'utilities.dart';
 
 part 'raw_config.g.dart';
 
@@ -24,33 +22,31 @@ class RawConfig {
 
   final RawCache? cache;
 
-  RawConfig({required this.oses, this.sdks, List<RawStage>? stages, this.cache})
-    : stages =
-          stages ??
-          [
-            RawStage('unit_test', ['test']),
-          ] {
-    if (sdks != null) {
-      sortNormalizeVerifySdksList(
-        Zone.current[_flavorKey] as PackageFlavor,
-        sdks!,
-        (m) => ArgumentError.value(sdks, 'sdks', m),
-      );
-    }
+  @JsonKey(name: 'pre_steps')
+  final List<Map>? preSteps;
+
+  @JsonKey(name: 'post_steps')
+  final List<Map>? postSteps;
+
+  RawConfig({
+    required this.oses,
+    this.sdks,
+    List<RawStage>? stages,
+    this.cache,
+    this.preSteps,
+    this.postSteps,
+  }) : stages =
+           stages ??
+           [
+             RawStage('unit_test', ['test']),
+           ] {
     oses.sort();
   }
 
-  factory RawConfig.fromYaml(PackageFlavor flavor, Map json, Pubspec pubspec) {
+  factory RawConfig.fromYaml(PackageFlavor flavor, Map json) {
     final config = runZoned(
       () => _$RawConfigFromJson(json),
       zoneValues: {_flavorKey: flavor},
-    );
-
-    handlePubspecInSdkList(
-      flavor,
-      config.sdks,
-      pubspec,
-      (m) => CheckedFromJsonException(json, 'sdk', 'RawConfig', m),
     );
 
     final stages = <String>{};

--- a/mono_repo/lib/src/raw_config.g.dart
+++ b/mono_repo/lib/src/raw_config.g.dart
@@ -8,33 +8,60 @@ part of 'raw_config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-RawConfig _$RawConfigFromJson(Map json) => $checkedCreate('RawConfig', json, (
-  $checkedConvert,
-) {
-  $checkKeys(json, allowedKeys: const ['os', 'sdk', 'stages', 'cache']);
-  final val = RawConfig(
-    oses: $checkedConvert(
-      'os',
-      (v) =>
-          (v as List<dynamic>?)?.map((e) => e as String).toList() ?? ['linux'],
-    ),
-    sdks: $checkedConvert(
-      'sdk',
-      (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
-    ),
-    stages: $checkedConvert(
-      'stages',
-      (v) => (v as List<dynamic>?)
-          ?.map((e) => RawStage.fromJson(e as Map))
-          .toList(),
-    ),
-    cache: $checkedConvert(
-      'cache',
-      (v) => v == null ? null : RawCache.fromJson(v as Map),
-    ),
-  );
-  return val;
-}, fieldKeyMap: const {'oses': 'os', 'sdks': 'sdk'});
+RawConfig _$RawConfigFromJson(Map json) => $checkedCreate(
+  'RawConfig',
+  json,
+  ($checkedConvert) {
+    $checkKeys(
+      json,
+      allowedKeys: const [
+        'os',
+        'sdk',
+        'stages',
+        'cache',
+        'pre_steps',
+        'post_steps',
+      ],
+    );
+    final val = RawConfig(
+      oses: $checkedConvert(
+        'os',
+        (v) =>
+            (v as List<dynamic>?)?.map((e) => e as String).toList() ??
+            ['linux'],
+      ),
+      sdks: $checkedConvert(
+        'sdk',
+        (v) => (v as List<dynamic>?)?.map((e) => e as String).toList(),
+      ),
+      stages: $checkedConvert(
+        'stages',
+        (v) => (v as List<dynamic>?)
+            ?.map((e) => RawStage.fromJson(e as Map))
+            .toList(),
+      ),
+      cache: $checkedConvert(
+        'cache',
+        (v) => v == null ? null : RawCache.fromJson(v as Map),
+      ),
+      preSteps: $checkedConvert(
+        'pre_steps',
+        (v) => (v as List<dynamic>?)?.map((e) => e as Map).toList(),
+      ),
+      postSteps: $checkedConvert(
+        'post_steps',
+        (v) => (v as List<dynamic>?)?.map((e) => e as Map).toList(),
+      ),
+    );
+    return val;
+  },
+  fieldKeyMap: const {
+    'oses': 'os',
+    'sdks': 'sdk',
+    'preSteps': 'pre_steps',
+    'postSteps': 'post_steps',
+  },
+);
 
 RawCache _$RawCacheFromJson(Map json) =>
     $checkedCreate('RawCache', json, ($checkedConvert) {

--- a/mono_repo/lib/src/root_config.dart
+++ b/mono_repo/lib/src/root_config.dart
@@ -22,6 +22,7 @@ const _pubspecFileName = 'pubspec.yaml';
 PackageConfig? _packageConfigFromDir(
   String rootDirectory,
   String pkgRelativePath,
+  MonoConfig monoConfig,
 ) {
   final legacyConfigPath = p.join(
     rootDirectory,
@@ -40,19 +41,22 @@ PackageConfig? _packageConfigFromDir(
 
   final pkgConfigYaml = yamlMapOrNull(rootDirectory, pkgConfigRelativePath);
 
-  if (pkgConfigYaml == null) {
-    return null;
-  }
-
   final pubspecFile = File(
     p.join(rootDirectory, pkgRelativePath, _pubspecFileName),
   );
 
   if (!pubspecFile.existsSync()) {
-    throw UserException(
-      'A `$monoPkgFileName` file was found, but missing'
-      ' an expected `$_pubspecFileName` in `$pkgRelativePath`.',
-    );
+    if (pkgConfigYaml != null) {
+      throw UserException(
+        'A `$monoPkgFileName` file was found, but missing'
+        ' an expected `$_pubspecFileName` in `$pkgRelativePath`.',
+      );
+    }
+    return null;
+  }
+
+  if (pkgConfigYaml == null && monoConfig.defaults.isEmpty) {
+    return null;
   }
 
   final pubspec = Pubspec.parse(
@@ -60,7 +64,12 @@ PackageConfig? _packageConfigFromDir(
     sourceUrl: Uri.parse(pubspecFile.path),
   );
 
-  return PackageConfig.parse(pkgRelativePath, pubspec, pkgConfigYaml);
+  return PackageConfig.parse(
+    pkgRelativePath,
+    pubspec,
+    pkgConfigYaml ?? const {},
+    defaults: monoConfig.defaults,
+  );
 }
 
 class RootConfig extends ListBase<PackageConfig> {
@@ -74,15 +83,29 @@ class RootConfig extends ListBase<PackageConfig> {
 
     final configs = <PackageConfig>[];
 
+    final monoConfig = MonoConfig.fromRepo(rootDirectory: rootDirectory);
+
+    final rootPkgConfig = _packageConfigFromDir(rootDirectory, '.', monoConfig);
+    if (rootPkgConfig != null) {
+      configs.add(rootPkgConfig);
+    }
+
     void visitDirectory(Directory directory) {
       final dirs = directory.listSync().whereType<Directory>().toList()
         ..sort((a, b) => a.path.compareTo(b.path));
       for (var subdir in dirs) {
-        final relativeSubDirPath = p.relative(subdir.path, from: rootDirectory);
+        final relativeSubDirPath = p.posix.joinAll(
+          p.split(p.relative(subdir.path, from: rootDirectory)),
+        );
+
+        if (monoConfig.ignore.contains(relativeSubDirPath)) {
+          continue;
+        }
 
         final pkgConfig = _packageConfigFromDir(
           rootDirectory!,
           relativeSubDirPath,
+          monoConfig,
         );
         if (pkgConfig != null) {
           configs.add(pkgConfig);
@@ -123,7 +146,7 @@ class RootConfig extends ListBase<PackageConfig> {
 
     return RootConfig._(
       rootDirectory,
-      MonoConfig.fromRepo(rootDirectory: rootDirectory),
+      monoConfig,
       configs,
       existingActionVersions,
     );

--- a/mono_repo/test/check_comand_test.dart
+++ b/mono_repo/test/check_comand_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:mono_repo/src/commands/check.dart';
 import 'package:mono_repo/src/root_config.dart';
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
@@ -29,13 +28,7 @@ void main() {
     test('check', () {
       final reports = getPackageReports(RootConfig(rootDirectory: d.sandbox));
 
-      expect(reports.keys, [
-        'bar',
-        'baz',
-        p.join('baz', 'recursive'),
-        'flutter',
-        'foo',
-      ]);
+      expect(reports.keys, ['bar', 'baz', 'baz/recursive', 'flutter', 'foo']);
 
       final fooReport = reports['foo']!;
       expect(fooReport.packageName, 'foo');
@@ -85,7 +78,7 @@ void main() {
           flutterReport.pubspec.dependencies['flutter'] as SdkDependency;
       expect(sdkDep.sdk, 'flutter');
 
-      final recursiveReport = reports[p.join('baz', 'recursive')]!;
+      final recursiveReport = reports['baz/recursive']!;
       expect(recursiveReport.packageName, 'baz.recursive');
       expect(recursiveReport.published, isTrue);
       expect(recursiveReport.pubspec.dependencies, hasLength(1));

--- a/mono_repo/test/defaults_test.dart
+++ b/mono_repo/test/defaults_test.dart
@@ -1,0 +1,79 @@
+import 'package:mono_repo/src/commands/github/github_yaml.dart';
+import 'package:mono_repo/src/yaml.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'shared.dart';
+
+void main() {
+  test('cascading defaults to subpackages without mono_pkg.yaml', () async {
+    await d.dir('sub_pkg', [
+      d.file('pubspec.yaml', '''
+name: pkg_name
+environment:
+  sdk: '^3.0.0'
+      '''),
+    ]).create();
+
+    final monoConfigContent = toYaml({
+      'defaults': {
+        'sdk': ['dev'],
+        'stages': [
+          {
+            'analyze': ['analyze'],
+          },
+        ],
+      },
+    });
+    await d.file('mono_repo.yaml', monoConfigContent).create();
+
+    testGenerateConfig(
+      printMatcher: stringContainsInOrder(['package:sub_pkg', 'Wrote ']),
+    );
+
+    await d
+        .file(defaultGitHubWorkflowFilePath, contains('sdk: "dev"'))
+        .validate();
+  });
+
+  test('subpackage overrides defaults', () async {
+    await d.dir('sub_pkg', [
+      d.file('mono_pkg.yaml', '''
+sdk:
+  - stable
+'''),
+      d.file('pubspec.yaml', '''
+name: pkg_name
+environment:
+  sdk: '^3.0.0'
+      '''),
+    ]).create();
+
+    final monoConfigContent = toYaml({
+      'defaults': {
+        'sdk': ['dev'],
+        'stages': [
+          {
+            'analyze': ['analyze'],
+          },
+        ],
+      },
+    });
+    await d.file('mono_repo.yaml', monoConfigContent).create();
+
+    testGenerateConfig(
+      printMatcher: stringContainsInOrder(['package:sub_pkg', 'Wrote ']),
+    );
+
+    // Should use stable SDK from mono_pkg.yaml, inheriting stages from defaults
+    await d
+        .file(defaultGitHubWorkflowFilePath, contains('sdk: "stable"'))
+        .validate();
+    await d
+        .file(defaultGitHubWorkflowFilePath, isNot(contains('sdk: "dev"')))
+        .validate();
+    await d
+        .file(defaultGitHubWorkflowFilePath, contains('sub_pkg; dart analyze'))
+        .validate();
+  });
+}

--- a/mono_repo/test/generate_test.dart
+++ b/mono_repo/test/generate_test.dart
@@ -820,7 +820,7 @@ $lines
           'other': {'stages': 5},
         },
         r'''
-line 2, column 3 of mono_repo.yaml: Unsupported value for "other". Only `github`, `merge_stages`, `pretty_ansi`, `pub_action`, `self_validate`, `coverage_service` keys are supported.
+line 2, column 3 of mono_repo.yaml: Unsupported value for "other". Only `github`, `merge_stages`, `pretty_ansi`, `pub_action`, `self_validate`, `coverage_service`, `defaults`, `ignore` keys are supported.
   ╷
 2 │   stages: 5
   │   ^^^^^^^^^
@@ -1392,6 +1392,40 @@ github:
 '''),
       ]).validate();
     });
+  });
+
+  test('pre_steps and post_steps render in workflow job', () async {
+    await d.dir('pkg_hooks', [
+      d.file('mono_pkg.yaml', '''
+sdk:
+  - dev
+pre_steps:
+  - run: echo "pre_step"
+post_steps:
+  - run: echo "post_step"
+stages:
+  - analyze:
+    - analyze
+'''),
+      d.file('pubspec.yaml', '''
+name: pkg_hooks
+environment:
+  sdk: '^3.0.0'
+'''),
+    ]).create();
+
+    await d.file('mono_repo.yaml', toYaml({})).create();
+
+    testGenerateConfig(
+      printMatcher: stringContainsInOrder(['package:pkg_hooks', 'Wrote ']),
+    );
+
+    await d
+        .file(defaultGitHubWorkflowFilePath, contains('pre_step'))
+        .validate();
+    await d
+        .file(defaultGitHubWorkflowFilePath, contains('post_step'))
+        .validate();
   });
 }
 

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:json_annotation/json_annotation.dart';
+import 'package:mono_repo/src/mono_config.dart';
 import 'package:mono_repo/src/package_config.dart';
 import 'package:mono_repo/src/yaml.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -305,7 +307,7 @@ line 7, column 9: Unsupported value for "a". Stages are required to have at leas
         'more': null,
       };
       _expectParseThrows(monoYaml, r'''
-line 2, column 2: Unrecognized keys: [extra, more]; supported keys: [os, sdk, stages, cache]
+line 2, column 2: Unrecognized keys: [extra, more]; supported keys: [os, sdk, stages, cache, pre_steps, post_steps]
   ╷
 2 │  "extra": "foo",
   │  ^^^^^^^
@@ -352,6 +354,28 @@ line 2, column 9: Unsupported value for "sdk". The value "latest" is neither a v
 4 │ │  ],
   │ └──^
   ╵''');
+    });
+
+    group('defaults and ignore', () {
+      test('valid map defaults and string list ignore', () {
+        final config = MonoConfig.fromJson({
+          'defaults': {
+            'sdk': ['dev'],
+          },
+          'ignore': ['sub_pkg_a'],
+        });
+        expect(config.defaults, {
+          'sdk': ['dev'],
+        });
+        expect(config.ignore, contains('sub_pkg_a'));
+      });
+
+      test('invalid defaults type throws', () {
+        expect(
+          () => MonoConfig.fromJson({'defaults': 'not_map'}),
+          throwsA(isA<CheckedFromJsonException>()),
+        );
+      });
     });
   });
 }

--- a/mono_repo/test/root_config_test.dart
+++ b/mono_repo/test/root_config_test.dart
@@ -2,8 +2,10 @@ import 'dart:io';
 
 import 'package:mono_repo/src/commands/github/github_yaml.dart';
 import 'package:mono_repo/src/root_config.dart';
+import 'package:mono_repo/src/yaml.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
   group('RootConfig', () {
@@ -18,6 +20,43 @@ void main() {
       final keys = parsedVersions.keys.toList();
       expect(keys, contains('actions/checkout'));
       expect(keys, contains('dart-lang/setup-dart'));
+    });
+
+    test('ignores directories in mono_repo.yaml ignore list', () async {
+      await d.dir('pkg_a', [
+        d.file('mono_pkg.yaml', 'sdk: [dev]'),
+        d.file('pubspec.yaml', 'name: pkg_a\nenvironment:\n  sdk: "^3.0.0"\n'),
+      ]).create();
+
+      await d.dir('pkg_b', [
+        d.file('mono_pkg.yaml', 'sdk: [dev]'),
+        d.file('pubspec.yaml', 'name: pkg_b\nenvironment:\n  sdk: "^3.0.0"\n'),
+      ]).create();
+
+      await d
+          .file(
+            'mono_repo.yaml',
+            toYaml({
+              'ignore': ['pkg_b'],
+            }),
+          )
+          .create();
+
+      final rootConfig = RootConfig(rootDirectory: d.sandbox);
+      expect(rootConfig.map((p) => p.relativePath), ['pkg_a']);
+    });
+
+    test('supports root package (.)', () async {
+      await d.file('pubspec.yaml', '''
+name: root_pkg
+environment:
+  sdk: "^3.0.0"
+''').create();
+      await d.file('mono_pkg.yaml', 'sdk: [dev]\n').create();
+      await d.file('mono_repo.yaml', toYaml({})).create();
+
+      final rootConfig = RootConfig(rootDirectory: d.sandbox);
+      expect(rootConfig.map((p) => p.relativePath), ['.']);
     });
   });
 }


### PR DESCRIPTION
## Summary

Second stage of the modular decomposition of mono_repo modernization (stacked on #528):
* Add `defaults:` parsing to `MonoConfig` and cascade root defaults to subpackages.
* Add `ignore:` list support to `MonoConfig` to skip specified directories.
* Add support for root package (`.`) in `RootConfig`.
* Add `pre_steps` and `post_steps` task hook support to `RawConfig` and `PackageConfig`.
* Add comprehensive unit tests in `defaults_test.dart`, `mono_config_test.dart`, and `root_config_test.dart`.