### PR TITLE
feat: add chronological SDK sorting with compareSdks

### DIFF
--- a/mono_repo/lib/src/utilities.dart
+++ b/mono_repo/lib/src/utilities.dart
@@ -80,17 +80,56 @@ void handlePubspecInSdkList(
   }
 }
 
+/// Compares two SDK strings chronologically:
+/// `pubspec` < SemVer versions < `stable` < `beta` < `dev` < `main`/`master`.
+int compareSdks(String a, String b) {
+  if (a == b) return 0;
+  if (a == _pubspecSdkKey) return -1;
+  if (b == _pubspecSdkKey) return 1;
+
+  const channelOrder = {
+    'stable': 1,
+    'beta': 2,
+    'dev': 3,
+    'main': 4,
+    'master': 4,
+  };
+  final rankA = channelOrder[a];
+  final rankB = channelOrder[b];
+
+  if (rankA != null && rankB != null) {
+    return rankA.compareTo(rankB);
+  }
+  if (rankA != null) {
+    return 1;
+  }
+  if (rankB != null) {
+    return -1;
+  }
+
+  try {
+    final vA = Version.parse(a);
+    final vB = Version.parse(b);
+    return vA.compareTo(vB);
+  } catch (_) {
+    return a.compareTo(b);
+  }
+}
+
 void sortNormalizeVerifySdksList(
   PackageFlavor flavor,
   List<String> sdks,
   Object Function(String message) errorFactory,
 ) {
-  sdks.sort();
   for (var i = 0; i < sdks.length; i++) {
     var value = sdks[i];
     if (flavor == PackageFlavor.dart && _allowedMainVersions.contains(value)) {
       sdks[i] = value = _githubSetupMainSdk;
     }
+  }
+  sdks.sort(compareSdks);
+  for (var i = 0; i < sdks.length; i++) {
+    final value = sdks[i];
     final error = errorForSdkConfig(flavor, value);
     if (error != null) {
       // ignore: only_throw_errors

--- a/mono_repo/test/mono_config_test.dart
+++ b/mono_repo/test/mono_config_test.dart
@@ -50,7 +50,7 @@ void main() {
 
     final config = _parse(monoYaml);
 
-    expect(config.sdks, ['1.23.0', 'dev', 'stable']);
+    expect(config.sdks, ['1.23.0', 'stable', 'dev']);
 
     final jobs = jsonDecode(
       jsonEncode(config.jobs.map((tj) => tj.toJson()).toList()),
@@ -447,7 +447,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'dev',
+    'sdk': 'stable',
     'stageName': 'unit_test',
     'tasks': [
       {'flavor': 'dart', 'type': 'test', 'args': '--platform chrome'},
@@ -457,7 +457,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'stable',
+    'sdk': 'dev',
     'stageName': 'unit_test',
     'tasks': [
       {'flavor': 'dart', 'type': 'test', 'args': '--platform chrome'},
@@ -481,7 +481,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'dev',
+    'sdk': 'stable',
     'stageName': 'unit_test',
     'tasks': [
       {
@@ -495,7 +495,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'stable',
+    'sdk': 'dev',
     'stageName': 'unit_test',
     'tasks': [
       {
@@ -523,7 +523,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'dev',
+    'sdk': 'stable',
     'stageName': 'unit_test',
     'tasks': [
       {
@@ -537,7 +537,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'stable',
+    'sdk': 'dev',
     'stageName': 'unit_test',
     'tasks': [
       {
@@ -561,7 +561,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'dev',
+    'sdk': 'stable',
     'stageName': 'unit_test',
     'tasks': [
       {'flavor': 'dart', 'type': 'test'},
@@ -571,7 +571,7 @@ List get _testConfig1expectedOutput => [
   {
     'os': 'linux',
     'package': 'a',
-    'sdk': 'stable',
+    'sdk': 'dev',
     'stageName': 'unit_test',
     'tasks': [
       {'flavor': 'dart', 'type': 'test'},

--- a/mono_repo/test/utilities_test.dart
+++ b/mono_repo/test/utilities_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:mono_repo/src/utilities.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('compareSdks', () {
+    test('identical strings return 0', () {
+      expect(compareSdks('stable', 'stable'), 0);
+      expect(compareSdks('3.0.0', '3.0.0'), 0);
+      expect(compareSdks('pubspec', 'pubspec'), 0);
+    });
+
+    test('orders pubspec before SemVer and channels', () {
+      expect(compareSdks('pubspec', '2.0.0'), lessThan(0));
+      expect(compareSdks('2.0.0', 'pubspec'), greaterThan(0));
+      expect(compareSdks('pubspec', 'stable'), lessThan(0));
+      expect(compareSdks('stable', 'pubspec'), greaterThan(0));
+    });
+
+    test('orders channels correctly', () {
+      final channels = ['main', 'dev', 'beta', 'stable']..sort(compareSdks);
+      expect(channels, ['stable', 'beta', 'dev', 'main']);
+
+      expect(compareSdks('main', 'master'), 0);
+    });
+
+    test('orders SemVer versions numerically', () {
+      final versions = ['3.1.0', '2.19.0', '3.0.0', '2.9.0']..sort(compareSdks);
+      expect(versions, ['2.9.0', '2.19.0', '3.0.0', '3.1.0']);
+    });
+
+    test('orders SemVer pre-releases before stable release', () {
+      final versions = ['3.0.0', '3.0.0-0.1.dev', '3.0.0-1.0.beta']
+        ..sort(compareSdks);
+      expect(versions, ['3.0.0-0.1.dev', '3.0.0-1.0.beta', '3.0.0']);
+    });
+
+    test('orders SemVer before channels', () {
+      expect(compareSdks('3.10.0', 'stable'), lessThan(0));
+      expect(compareSdks('stable', '3.10.0'), greaterThan(0));
+      expect(compareSdks('99.99.99', 'dev'), lessThan(0));
+    });
+
+    test('falls back to string compare for unparseable strings', () {
+      expect(compareSdks('custom_a', 'custom_b'), lessThan(0));
+      expect(compareSdks('custom_b', 'custom_a'), greaterThan(0));
+    });
+
+    test('sorts mixed collection of SDK targets', () {
+      final sdks = [
+        'main',
+        'dev',
+        'pubspec',
+        '3.0.0',
+        'stable',
+        'beta',
+        '2.19.0',
+        'custom_b',
+        'custom_a',
+      ]..sort(compareSdks);
+      expect(sdks, [
+        'pubspec',
+        '2.19.0',
+        '3.0.0',
+        'custom_a',
+        'custom_b',
+        'stable',
+        'beta',
+        'dev',
+        'main',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Why

Previously, SDK versions in package configurations were sorted alphabetically (`sdks.sort()`). This resulted in counterintuitive ordering:
* Channels were sorted alphabetically (`dev` < `main` < `pubspec` < `stable`), placing `dev` before `stable`.
* Mixed SemVer and channel lists lacked a consistent progression from minimum supported to bleeding edge.

## What

Introduces `compareSdks` to enforce a deterministic chronological SDK sorting order:
`pubspec` (minimum SDK constraint) < SemVer versions (e.g. `2.19.0` < `3.0.0`) < `stable` < `beta` < `dev` < `main` / `master` (bleeding edge).

### Details
* **Channel Lifecycle**: Orders channels by release maturity (`stable` -> `beta` -> `dev` -> `main`).
* **SemVer Comparison**: Correctly compares SemVer releases and pre-releases numerically rather than lexicographically.
* **Fallback Safety**: Gracefully falls back to string comparison for custom or unparseable SDK strings.
* **Unit Tests**: Adds comprehensive test coverage in `test/utilities_test.dart`.
* **CI Predictability**: Ensures generated GitHub Actions matrix jobs appear in a clean, logical order and establishes the foundation for reliably identifying the newest SDK.