### PR TITLE
Fix AOT SDK discovery using package:cli_util

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.7.3-wip
+# Created with package:mono_repo v6.7.3
 name: Dart CI
 on:
   push:

--- a/mono_repo/CHANGELOG.md
+++ b/mono_repo/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 6.7.3-wip
+## 6.7.3
 
+- Fix SDK discovery when compiled via AOT (`dart install` / `dart compile exe`).
 - Fix multi-line string round-tripping in `toYaml()` by using strip chomping (`|-`).
 
 ## 6.7.2

--- a/mono_repo/lib/src/commands/dart.dart
+++ b/mono_repo/lib/src/commands/dart.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:cli_util/cli_util.dart';
 import 'package:io/ansi.dart';
 import 'package:path/path.dart' as p;
 
@@ -95,16 +96,8 @@ Future<void> dart(
   }
 }
 
-/// The path to the root directory of the SDK.
-final String _sdkDir = (() {
-  // The Dart executable is in "/path/to/sdk/bin/dart", so two levels up is
-  // "/path/to/sdk".
-  final aboveExecutable = p.dirname(p.dirname(Platform.resolvedExecutable));
-  assert(FileSystemEntity.isFileSync(p.join(aboveExecutable, 'version')));
-  return aboveExecutable;
-})();
-
-final String _dartPath = p.join(_sdkDir, 'bin', 'dart');
+/// The path to the dart executable.
+final String _dartPath = dartExecutable ?? 'dart';
 
 /// The "flutter[.bat]" command.
 final String _flutterPath = Platform.isWindows ? 'flutter.bat' : 'flutter';

--- a/mono_repo/lib/src/version.dart
+++ b/mono_repo/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '6.7.3-wip';
+const packageVersion = '6.7.3';

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -15,6 +15,7 @@ environment:
 dependencies:
   args: ^2.0.0
   checked_yaml: ^2.0.1
+  cli_util: ^0.6.0
   collection: ^1.19.0
   graphs: ^2.2.0
   io: ^1.0.0

--- a/mono_repo/pubspec.yaml
+++ b/mono_repo/pubspec.yaml
@@ -2,7 +2,7 @@ name: mono_repo
 description: >-
   CLI tools to make it easier to manage a single source repository containing
   multiple Dart packages.
-version: 6.7.3-wip
+version: 6.7.3
 repository: https://github.com/google/mono_repo.dart
 
 topics:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.7.3-wip
+# Created with package:mono_repo v6.7.3
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
Under AOT compilation (e.g., `dart compile exe` or `dart install`), `Platform.resolvedExecutable` points to the compiled binary itself rather than the Dart SDK's `bin/dart`. This caused `mono_repo` to fail SDK path resolution, crashing the application with an assertion error.

This commit incorporates `package:cli_util` and uses its robust `dartExecutable` getter to accurately resolve the Dart executable path regardless of execution format (JIT or AOT).

Fixes AOT compilation support for mono_repo.